### PR TITLE
Plugin minimalistic status responses

### DIFF
--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -163,16 +163,16 @@ class HcuApiClient:
                     future.set_result(response_body.get("body"))
         elif msg_type == "PLUGIN_STATE_REQUEST":
             _LOGGER.debug("Received PLUGIN_STATE_REQUEST: %s", msg)
-            self._send_plugin_ready(msg_id)
+            asyncio.create_task(self._send_plugin_ready(msg_id))
         elif msg_type == "DISCOVER_REQUEST":
             _LOGGER.debug("Received DISCOVER_REQUEST: %s", msg)
-            self._send_discover_response(msg_id)
+            asyncio.create_task(self._send_discover_response(msg_id))
         elif msg_type == "CONFIG_TEMPLATE_REQUEST":
             _LOGGER.debug("Received CONFIG_TEMPLATE_REQUEST: %s", msg)
-            self._send_config_template_response(msg_id)
+            asyncio.create_task(self._send_config_template_response(msg_id))
         elif msg_type == "CONFIG_UPDATE_REQUEST":
             _LOGGER.debug("Received CONFIG_UPDATE_REQUEST: %s", msg)
-            self._send_config_update_response(msg_id)
+            asyncio.create_task(self._send_config_update_response(msg_id))
         elif self._event_callback:
             self._event_callback(msg)
 

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -161,6 +161,18 @@ class HcuApiClient:
                     future.set_exception(HcuApiError(f"HCU Error: {response_body}"))
                 else:
                     future.set_result(response_body.get("body"))
+        elif msg_type == "PLUGIN_STATE_REQUEST":
+            _LOGGER.debug("Received PLUGIN_STATE_REQUEST: %s", msg)
+            self._send_plugin_ready(msg_id)
+        elif msg_type == "DISCOVER_REQUEST":
+            _LOGGER.debug("Received DISCOVER_REQUEST: %s", msg)
+            self._send_discover_response(msg_id)
+        elif msg_type == "CONFIG_TEMPLATE_REQUEST":
+            _LOGGER.debug("Received CONFIG_TEMPLATE_REQUEST: %s", msg)
+            self._send_config_template_response(msg_id)
+        elif msg_type == "CONFIG_UPDATE_REQUEST":
+            _LOGGER.debug("Received CONFIG_UPDATE_REQUEST: %s", msg)
+            self._send_config_update_response(msg_id)
         elif self._event_callback:
             self._event_callback(msg)
 
@@ -239,6 +251,46 @@ class HcuApiClient:
         raise HcuApiError(
             f"Request failed after multiple retries for path {path}"
         ) from last_exception
+
+    async def _send_plugin_ready(self, message_id: str) -> None:
+        """Notify the HCU that the plugin is ready to receive events."""
+        message = {
+            "id": message_id,
+            "pluginId": self.plugin_id,
+            "type": "PLUGIN_STATE_RESPONSE",
+            "body": {"pluginReadinessStatus": "READY"},
+        }
+        await self._send_message(message)
+
+    async def _send_discover_response(self, message_id: str) -> None:
+        """Notify the HCU that the plugin is ready to receive events."""
+        message = {
+            "id": message_id,
+            "pluginId": self.plugin_id,
+            "type": "DISCOVER_RESPONSE",
+            "body": {"success": "true", "devices": []},
+        }
+        await self._send_message(message)
+
+    async def _send_config_template_response(self, message_id: str) -> None:
+        """Notify the HCU that the plugin is ready to receive events."""
+        message = {
+            "id": message_id,
+            "pluginId": self.plugin_id,
+            "type": "CONFIG_TEMPLATE_RESPONSE",
+            "body": {"properties": {}},
+        }
+        await self._send_message(message)
+
+    async def _send_config_update_response(self, message_id: str) -> None:
+        """Notify the HCU that the plugin is ready to receive events."""
+        message = {
+            "id": message_id,
+            "pluginId": self.plugin_id,
+            "type": "CONFIG_UPDATE_RESPONSE",
+            "body": {"status": "APPLIED"},
+        }
+        await self._send_message(message)
 
     async def get_system_state(self) -> dict[str, Any]:
         """Fetch the complete system state from the HCU."""

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -161,18 +161,20 @@ class HcuApiClient:
                     future.set_exception(HcuApiError(f"HCU Error: {response_body}"))
                 else:
                     future.set_result(response_body.get("body"))
-        elif msg_type == "PLUGIN_STATE_REQUEST":
-            _LOGGER.debug("Received PLUGIN_STATE_REQUEST: %s", msg)
-            asyncio.create_task(self._send_plugin_ready(msg_id))
-        elif msg_type == "DISCOVER_REQUEST":
-            _LOGGER.debug("Received DISCOVER_REQUEST: %s", msg)
-            asyncio.create_task(self._send_discover_response(msg_id))
-        elif msg_type == "CONFIG_TEMPLATE_REQUEST":
-            _LOGGER.debug("Received CONFIG_TEMPLATE_REQUEST: %s", msg)
-            asyncio.create_task(self._send_config_template_response(msg_id))
-        elif msg_type == "CONFIG_UPDATE_REQUEST":
-            _LOGGER.debug("Received CONFIG_UPDATE_REQUEST: %s", msg)
-            asyncio.create_task(self._send_config_update_response(msg_id))
+        elif msg_type in (
+            "PLUGIN_STATE_REQUEST",
+            "DISCOVER_REQUEST",
+            "CONFIG_TEMPLATE_REQUEST",
+            "CONFIG_UPDATE_REQUEST",
+        ):
+            _LOGGER.debug("Received %s: %s", msg_type, msg)
+            handler_map = {
+                "PLUGIN_STATE_REQUEST": self._send_plugin_ready,
+                "DISCOVER_REQUEST": self._send_discover_response,
+                "CONFIG_TEMPLATE_REQUEST": self._send_config_template_response,
+                "CONFIG_UPDATE_REQUEST": self._send_config_update_response,
+            }
+            asyncio.create_task(handler_map[msg_type](msg_id))
         elif self._event_callback:
             self._event_callback(msg)
 


### PR DESCRIPTION
With this PR I added the minimal handling of plugin status requests/responses like

- PLUGIN_STATE_REQUEST
- DISCOVER_REQUEST
- CONFIG_TEMPLATE_REQUEST
- CONFIG_UPDATE_REQUEST

With this the plugin will reported as ready and running in the HCU WebUI
<img width="480" height="249" alt="image" src="https://github.com/user-attachments/assets/108838bc-ae88-4758-9248-9529c592c9b9" />

It is also introducing a minimal plugin configuration (without any options), which avoids the infinite loading screen.
<img width="1028" height="505" alt="image" src="https://github.com/user-attachments/assets/67916873-087d-43b2-b634-ebf14f2cc00d" />

Configuration can also be saved (saves nothing) and it will be confirmed.