### PR TITLE
Add on-time sensor for Extended Linked Switching groups

### DIFF
--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -501,7 +501,10 @@ async def async_discover_entities(
         "SWITCHING_PROFILE": (Platform.SWITCH, switch.HcuSwitchGroup, {}),
         "LINKED_SWITCHING": (Platform.SWITCH, switch.HcuSwitchGroup, {}),
         "LIGHT": (Platform.LIGHT, light.HcuLightGroup, {}),
-        "EXTENDED_LINKED_SWITCHING": (Platform.SWITCH, switch.HcuSwitchGroup, {}),
+        "EXTENDED_LINKED_SWITCHING": [
+            (Platform.SWITCH, switch.HcuSwitchGroup, {}),
+            (Platform.SENSOR, sensor.HcuGroupOnTimeSensor, {}),
+        ],
         "EXTENDED_LINKED_SHUTTER": (Platform.COVER, cover.HcuCoverGroup, {}),
         "EXTENDED_LINKED_NOTIFICATION": (Platform.LIGHT, light.HcuLightGroup, {}),
         "EXTENDED_LINKED_WATERING": (Platform.SWITCH, switch.HcuWateringGroup, {}),

--- a/custom_components/hcu_integration/sensor.py
+++ b/custom_components/hcu_integration/sensor.py
@@ -85,6 +85,8 @@ class HcuGroupOnTimeSensor(HcuGroupBaseEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_native_unit_of_measurement = "s"
     _attr_suggested_display_precision = 0
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(
         self,

--- a/custom_components/hcu_integration/sensor.py
+++ b/custom_components/hcu_integration/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
 from .api import HcuApiClient
-from .entity import HcuBaseEntity, HcuHomeBaseEntity
+from .entity import HcuBaseEntity, HcuGroupBaseEntity, HcuHomeBaseEntity
 from .const import (
     HMIP_ON_TIME_INFINITE,
 )
@@ -74,6 +74,37 @@ class HcuHomeSensor(HcuHomeBaseEntity, SensorEntity):
             return round(value, 1)
 
         return value
+
+
+class HcuGroupOnTimeSensor(HcuGroupBaseEntity, SensorEntity):
+    """Representation of the configured on-time of an Extended Linked Switching group."""
+
+    PLATFORM = Platform.SENSOR
+    _attr_has_entity_name = True
+    _attr_translation_key = "hcu_group_on_time"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "s"
+    _attr_suggested_display_precision = 0
+
+    def __init__(
+        self,
+        coordinator: "HcuCoordinator",
+        client: HcuApiClient,
+        group_data: dict,
+    ) -> None:
+        super().__init__(coordinator, client, group_data)
+        del self._attr_name  # let translation_key supply the entity name component
+        self._attr_unique_id = f"{self._group_id}_on_time"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the configured on-time in seconds."""
+        value = self._group.get("onTime")
+        if value is None:
+            return None
+        if value == HMIP_ON_TIME_INFINITE:
+            return 0
+        return round(value, 0)
 
 
 class HcuGenericSensor(HcuBaseEntity, SensorEntity):

--- a/custom_components/hcu_integration/translations/de.json
+++ b/custom_components/hcu_integration/translations/de.json
@@ -477,6 +477,9 @@
       },
       "hcu_on_time": {
         "name": "{channel}Interne Einschaltdauer"
+      },
+      "hcu_group_on_time": {
+        "name": "Einschaltdauer"
       }
     },
     "text": {

--- a/custom_components/hcu_integration/translations/en.json
+++ b/custom_components/hcu_integration/translations/en.json
@@ -477,6 +477,9 @@
       },
       "hcu_on_time": {
         "name": "{channel}Internal On-time"
+      },
+      "hcu_group_on_time": {
+        "name": "On-time"
       }
     },
     "text": {


### PR DESCRIPTION
## Description
Adds a new `sensor` entity that exposes the configured `onTime` (auto switch-off delay) of `EXTENDED_LINKED_SWITCHING` groups, alongside the existing `switch` entity for that group type.

## Motivation & Context
`EXTENDED_LINKED_SWITCHING` groups carry a group-level `onTime` field (the auto-off delay configured for the "Extended Linked Switching" group), which wasn't previously surfaced as an entity. This makes that value visible in Home Assistant.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## Changes
- `sensor.py`: new `HcuGroupOnTimeSensor` class reading `onTime` from the group data, treated as a duration sensor (seconds), diagnostic category, **disabled by default** (matches the existing channel-level on-time sensor behavior).
- `discovery.py`: `EXTENDED_LINKED_SWITCHING` group mapping now creates both the switch entity and the new sensor entity.
- `translations/en.json` / `translations/de.json`: added `hcu_group_on_time` translation key ("On-time" / "Einschaltdauer").

## How Was It Tested?
- [ ] Unit tests
- [x] Manually tested
  - Verified Python syntax and JSON validity of all changed files.
  - Ran `ruff check` on changed files; no new lint issues introduced (pre-existing unused-import warnings in `discovery.py`/`sensor.py` are unrelated to this change).
  - No local Home Assistant test environment available in this session, so live entity behavior wasn't verified against a running HCU.

## Checklist
- [x] Code follows the project style
- [ ] Tests added
- [x] Documentation updated (translations)


---
_Generated by [Claude Code](https://claude.ai/code/session_013woKCjP1mi3MNxgYXcBg3k)_