### PR TITLE
Add API send/receive debug logging for HCU WebSocket and REST traffic

### DIFF
--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -32,6 +32,7 @@ from .const import (
     CONF_PLUGIN_TOKEN,
     CONF_WEBSOCKET_PORT,
     CONF_ADVANCED_DEBUGGING,
+    DEFAULT_ADVANCED_DEBUGGING,
     CHANNEL_TYPE_MULTI_MODE_INPUT_TRANSMITTER,
     DEFAULT_HCU_AUTH_PORT,
     DEFAULT_HCU_WEBSOCKET_PORT,
@@ -132,6 +133,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         auth_type=entry.data.get(CONF_AUTH_TYPE, ""),
         access_point_id=entry.data.get(CONF_HCU_SGTIN, ""),
         app_token=entry.data.get(CONF_APP_TOKEN, ""),
+        advanced_debugging=entry.options.get(CONF_ADVANCED_DEBUGGING, DEFAULT_ADVANCED_DEBUGGING),
     )
 
     coordinator = HcuCoordinator(hass, client, entry)

--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -214,7 +214,7 @@ class HcuCoordinator(DataUpdateCoordinator[set[str]]):
         self._known_device_ids: set[str] = set()
         self.advanced_debugging = self.config_entry.options.get(
             CONF_ADVANCED_DEBUGGING,
-            False,
+            DEFAULT_ADVANCED_DEBUGGING,
         )
         self._previous_options = dict(self.config_entry.options)
         self._initial_state_loaded = False

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -359,8 +359,7 @@ class HcuApiClient:
         }
         ssl_context = await create_unverified_ssl_context(self.hass)
         _LOGGER.info("App User: fetching state via REST POST %s", url)
-        if self._advanced_debugging:
-            _LOGGER.debug("API → REST POST %s body=%s", url, body)
+        _LOGGER.debug("API → REST POST %s body=%s", url, body)
         try:
             async with self._session.post(url, headers=headers, json=body, ssl=ssl_context) as resp:
                 if not resp.ok:
@@ -608,8 +607,7 @@ class HcuApiClient:
             else "App User WS" if self._auth_type in (AUTH_TYPE_APP, AUTH_TYPE_DUAL)
             else "Plugin User WS"
         )
-        if self._advanced_debugging:
-            _LOGGER.debug("API → %s (%s): %s", msg_type, target, message)
+        _LOGGER.debug("API → %s (%s): %s", msg_type, target, message)
         if is_plugin_route:
             if not self.is_plugin_connected or self._plugin_websocket is None:
                 raise ConnectionError("Plugin WebSocket not connected (DualBridge).")

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -359,7 +359,7 @@ class HcuApiClient:
         }
         ssl_context = await create_unverified_ssl_context(self.hass)
         _LOGGER.info("App User: fetching state via REST POST %s", url)
-        _LOGGER.debug("API → REST POST %s body=%s", url, body)
+        _LOGGER.debug("API → REST POST body=%s", body)
         try:
             async with self._session.post(url, headers=headers, json=body, ssl=ssl_context) as resp:
                 if not resp.ok:
@@ -496,6 +496,8 @@ class HcuApiClient:
                 _LOGGER.warning("Received %s without message ID, cannot respond", msg_type)
                 return
 
+            _LOGGER.debug("Received %s: %s", msg_type, msg)
+
             if msg_type == "CONTROL_REQUEST":
                 asyncio.create_task(self._handle_control_request(msg))
             else:
@@ -593,11 +595,13 @@ class HcuApiClient:
         "USER_MESSAGE_ACK_EVENT",
     })
 
-    async def _send_message(self, message: dict[str, Any]) -> None:
+    async def _send_message(self, message: dict[str, Any], log_body: bool = True) -> None:
         """Send a JSON message over the appropriate WebSocket.
 
         In DualBridge mode, Plugin-only message types are routed to the Plugin
         User WebSocket (port 9001); all other messages go to the primary socket.
+        `log_body` can be set to False to suppress the body dump on retries of
+        an already-logged message (e.g. from _send_hmip_request's retry loop).
         """
         msg_type = message.get("type")
         is_plugin_route = self._auth_type == AUTH_TYPE_DUAL and msg_type in self._PLUGIN_ONLY_MESSAGE_TYPES
@@ -607,7 +611,8 @@ class HcuApiClient:
             else "App User WS" if self._auth_type in (AUTH_TYPE_APP, AUTH_TYPE_DUAL)
             else "Plugin User WS"
         )
-        _LOGGER.debug("API → %s (%s): %s", msg_type, target, message)
+        if log_body:
+            _LOGGER.debug("API → %s (%s): %s", msg_type, target, message)
         if is_plugin_route:
             if not self.is_plugin_connected or self._plugin_websocket is None:
                 raise ConnectionError("Plugin WebSocket not connected (DualBridge).")
@@ -644,7 +649,7 @@ class HcuApiClient:
             self._pending_requests[message_id] = future
 
             try:
-                await self._send_message(message)
+                await self._send_message(message, log_body=(attempt == 0))
                 result = await asyncio.wait_for(future, timeout=timeout)
                 if attempt > 0:
                     _LOGGER.info(

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -53,6 +53,21 @@ _LOGGER = logging.getLogger(__name__)
 # Model type prefixes for auxiliary access points (not primary HCU controllers)
 HAP_DRAP_PREFIXES = ("HmIP-HAP", "HmIP-DRAP", "HmIP-WLAN-HAP", "HmIPW-DRAP")
 
+# Message/body keys that must never appear in plain text in log output
+_SENSITIVE_LOG_KEYS = ("authorizationPin",)
+
+
+def _redact_for_log(data: Any) -> Any:
+    """Return a deep copy of a message dict/list with sensitive values masked for logging."""
+    if isinstance(data, dict):
+        return {
+            key: "***" if key in _SENSITIVE_LOG_KEYS else _redact_for_log(value)
+            for key, value in data.items()
+        }
+    if isinstance(data, list):
+        return [_redact_for_log(item) for item in data]
+    return data
+
 
 class HcuApiError(Exception):
     """Custom exception for API errors returned by the HCU."""
@@ -357,6 +372,7 @@ class HcuApiClient:
         }
         ssl_context = await create_unverified_ssl_context(self.hass)
         _LOGGER.info("App User: fetching state via REST POST %s", url)
+        _LOGGER.debug("API → REST POST %s body=%s", url, body)
         try:
             async with self._session.post(url, headers=headers, json=body, ssl=ssl_context) as resp:
                 if not resp.ok:
@@ -455,6 +471,8 @@ class HcuApiClient:
         msg_type = msg.get("type")
         msg_id = msg.get("id")
 
+        _LOGGER.debug("API ← %s (id=%s): %s", msg_type, msg_id, _redact_for_log(msg))
+
         if msg_type == "HMIP_SYSTEM_RESPONSE" and msg_id in self._pending_requests:
             future = self._pending_requests.pop(msg_id)
             if not future.done():
@@ -490,8 +508,6 @@ class HcuApiClient:
                 _LOGGER.warning("Received %s without message ID, cannot respond", msg_type)
                 return
 
-            _LOGGER.debug("Received %s: %s", msg_type, msg)
-            
             if msg_type == "CONTROL_REQUEST":
                 asyncio.create_task(self._handle_control_request(msg))
             else:
@@ -596,7 +612,15 @@ class HcuApiClient:
         User WebSocket (port 9001); all other messages go to the primary socket.
         """
         msg_type = message.get("type")
-        if self._auth_type == AUTH_TYPE_DUAL and msg_type in self._PLUGIN_ONLY_MESSAGE_TYPES:
+        is_plugin_route = self._auth_type == AUTH_TYPE_DUAL and msg_type in self._PLUGIN_ONLY_MESSAGE_TYPES
+        target = (
+            "Plugin WS (DualBridge secondary)"
+            if is_plugin_route
+            else "App User WS" if self._auth_type in (AUTH_TYPE_APP, AUTH_TYPE_DUAL)
+            else "Plugin User WS"
+        )
+        _LOGGER.debug("API → %s (%s): %s", msg_type, target, _redact_for_log(message))
+        if is_plugin_route:
             if not self.is_plugin_connected or self._plugin_websocket is None:
                 raise ConnectionError("Plugin WebSocket not connected (DualBridge).")
             await self._plugin_websocket.send_json(message)

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -53,21 +53,6 @@ _LOGGER = logging.getLogger(__name__)
 # Model type prefixes for auxiliary access points (not primary HCU controllers)
 HAP_DRAP_PREFIXES = ("HmIP-HAP", "HmIP-DRAP", "HmIP-WLAN-HAP", "HmIPW-DRAP")
 
-# Message/body keys that must never appear in plain text in log output
-_SENSITIVE_LOG_KEYS = ("authorizationPin",)
-
-
-def _redact_for_log(data: Any) -> Any:
-    """Return a deep copy of a message dict/list with sensitive values masked for logging."""
-    if isinstance(data, dict):
-        return {
-            key: "***" if key in _SENSITIVE_LOG_KEYS else _redact_for_log(value)
-            for key, value in data.items()
-        }
-    if isinstance(data, list):
-        return [_redact_for_log(item) for item in data]
-    return data
-
 
 class HcuApiError(Exception):
     """Custom exception for API errors returned by the HCU."""
@@ -91,6 +76,7 @@ class HcuApiClient:
         auth_type: str = "",
         access_point_id: str = "",
         app_token: str = "",
+        advanced_debugging: bool = False,
     ) -> None:
         """Initialize the API client."""
         self.hass = hass
@@ -99,6 +85,7 @@ class HcuApiClient:
         self._auth_type = auth_type
         self._access_point_id = access_point_id
         self._app_token = app_token
+        self._advanced_debugging = advanced_debugging
         self._client_auth = (
             hashlib.sha512(
                 (access_point_id + "jiLpVitHvWnIGD1yo7MA").encode("utf-8")
@@ -372,7 +359,8 @@ class HcuApiClient:
         }
         ssl_context = await create_unverified_ssl_context(self.hass)
         _LOGGER.info("App User: fetching state via REST POST %s", url)
-        _LOGGER.debug("API → REST POST %s body=%s", url, body)
+        if self._advanced_debugging:
+            _LOGGER.debug("API → REST POST %s body=%s", url, body)
         try:
             async with self._session.post(url, headers=headers, json=body, ssl=ssl_context) as resp:
                 if not resp.ok:
@@ -471,7 +459,8 @@ class HcuApiClient:
         msg_type = msg.get("type")
         msg_id = msg.get("id")
 
-        _LOGGER.debug("API ← %s (id=%s): %s", msg_type, msg_id, _redact_for_log(msg))
+        if self._advanced_debugging:
+            _LOGGER.debug("API ← %s (id=%s): %s", msg_type, msg_id, msg)
 
         if msg_type == "HMIP_SYSTEM_RESPONSE" and msg_id in self._pending_requests:
             future = self._pending_requests.pop(msg_id)
@@ -619,7 +608,8 @@ class HcuApiClient:
             else "App User WS" if self._auth_type in (AUTH_TYPE_APP, AUTH_TYPE_DUAL)
             else "Plugin User WS"
         )
-        _LOGGER.debug("API → %s (%s): %s", msg_type, target, _redact_for_log(message))
+        if self._advanced_debugging:
+            _LOGGER.debug("API → %s (%s): %s", msg_type, target, message)
         if is_plugin_route:
             if not self.is_plugin_connected or self._plugin_websocket is None:
                 raise ConnectionError("Plugin WebSocket not connected (DualBridge).")


### PR DESCRIPTION
## Description
Adds debug-level logging for every API command sent to and received from the HCU, covering both connection types:
- **Outgoing**: WebSocket sends (`_send_message`, used by Plugin User and DualBridge's plugin-secondary channel) and REST calls (`_async_get_current_state_rest`, `_async_app_rest_call`) are always logged at `debug`, independent of auth type.
- **Incoming**: WebSocket receives (`_handle_incoming_message`) are logged at `debug` only when the existing **Advanced Debugging** developer-mode option is enabled, since incoming traffic includes frequent, high-volume push events (every device state change) and can include full system-state dumps.

Also:
- `HcuApiClient` now takes an `advanced_debugging` bool at construction time, sourced from the config entry's existing `advanced_debugging` option (same option `HcuCoordinator` already reads).
- Restored an unconditional debug log for plugin lifecycle requests (`PLUGIN_STATE_REQUEST`, `DISCOVER_REQUEST`, `CONTROL_REQUEST`, `CONFIG_TEMPLATE_REQUEST`, `CONFIG_UPDATE_REQUEST`) so it keeps working under plain component-level `debug` logging, independent of the Advanced Debugging toggle.
- `_send_hmip_request`'s retry loop no longer re-logs the full message body on every retry attempt — only the first attempt logs the payload.
- Minor cleanup: removed a duplicate log line in `_async_get_current_state_rest`, and `HcuCoordinator` now reuses the `DEFAULT_ADVANCED_DEBUGGING` constant instead of a separately hardcoded default.

## Motivation & Context
Troubleshooting HCU connectivity/command issues currently requires piecing together partial log output — some commands and responses were logged, others (notably most WebSocket traffic for Plugin User and DualBridge's plugin channel) were not logged at all. This makes it hard to see exactly what was sent to or received from the HCU when diagnosing an issue. This change makes every API command/response visible in the log, gating the high-volume incoming side behind the existing Advanced Debugging option to avoid flooding logs by default.

**Known limitation:** removing the previous PIN-redaction logic means the WebSocket logging paths no longer mask `authorizationPin` (used by door-lock commands) before logging it, so it can appear in plaintext in debug logs. This mirrors the pre-existing behavior of the REST command log (`_async_app_rest_call`), which has never masked it either. Flagging this here as a known follow-up rather than addressing it in this PR.

## Type of Change
- [x] Bug fix (restores lost debug visibility for plugin lifecycle messages, fixes retry log duplication)
- [x] New feature (API send/receive logging)
- [ ] Breaking change
- [ ] Documentation

## How Was It Tested?
- [x] Unit tests (existing suite run via a local Python 3.12 + `pytest-homeassistant-custom-component` venv; no new failures introduced — pre-existing unrelated failures in `test_api.py`, `test_coordinator.py`, `test_entity.py`, `test_api_device_identification.py` are unchanged before/after)
- [x] Manually tested (`py_compile` on changed files, and manual invocation of `_send_message`/`_handle_incoming_message` to confirm gating behavior and retry log suppression)

## Checklist
- [x] Code follows the project style
- [ ] Tests added
- [ ] Documentation updated


---
_Generated by [Claude Code](https://claude.ai/code/session_01NiAkbz2gXLdrMjx7HHwgrA)_