### PR TITLE
Fix alarm control panel UNKNOWN_GROUP error after HmIP 1.79 zone rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
+## 2.1.3 - 2026-07-23
+
+### 🔧 Fixes & Improvements
+
+- **Alarm control panel broken after HmIP 1.79 update** — HmIP's 1.79 HCU firmware renamed the security zone groups used by `setExtendedZonesActivation` (`INTERNAL`/`EXTERNAL` → `PRESENCE`/`ABSENCE`), which caused arm/disarm requests to fail with `UNKNOWN_GROUP`. The integration now detects which zone names the HCU currently reports and uses those, so it works on firmware before and after the rename. On 1.79+ firmware, arming home/away now activates only the single matching zone instead of both at once, matching the new mutually-exclusive PRESENCE/ABSENCE model. (#417)
+
 ## 2.1.2 - 2026-07-12
 
 ### 🔧 Fixes & Improvements

--- a/custom_components/hcu_integration/alarm_control_panel.py
+++ b/custom_components/hcu_integration/alarm_control_panel.py
@@ -35,6 +35,14 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
+# HmIP renamed the security zone groups with the 1.79 HCU firmware (new alarm
+# system): the interior zone "INTERNAL" became "ABSENCE" and the perimeter
+# zone "EXTERNAL" became "PRESENCE". Support both so the integration keeps
+# working regardless of which firmware generation the HCU is running.
+_ZONE_INTERIOR_KEYS = ("INTERNAL", "ABSENCE")
+_ZONE_PERIMETER_KEYS = ("EXTERNAL", "PRESENCE")
+
+
 class HcuAlarmControlPanel(HcuHomeBaseEntity, AlarmControlPanelEntity):
     """Representation of the HCU Security System."""
 
@@ -58,6 +66,17 @@ class HcuAlarmControlPanel(HcuHomeBaseEntity, AlarmControlPanelEntity):
             if home.get("solution") == "SECURITY_AND_ALARM":
                 return home
         return {}
+
+    @staticmethod
+    def _zone_keys(zones: dict) -> tuple[str, str]:
+        """Return the (interior, perimeter) zone key names currently used by the HCU."""
+        interior_key = next(
+            (key for key in _ZONE_INTERIOR_KEYS if key in zones), _ZONE_INTERIOR_KEYS[-1]
+        )
+        perimeter_key = next(
+            (key for key in _ZONE_PERIMETER_KEYS if key in zones), _ZONE_PERIMETER_KEYS[-1]
+        )
+        return interior_key, perimeter_key
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -93,8 +112,9 @@ class HcuAlarmControlPanel(HcuHomeBaseEntity, AlarmControlPanelEntity):
             )
             return AlarmControlPanelState.DISARMED
 
-        internal_group_id = zones.get("INTERNAL")
-        external_group_id = zones.get("EXTERNAL")
+        interior_key, perimeter_key = self._zone_keys(zones)
+        internal_group_id = zones.get(interior_key)
+        external_group_id = zones.get(perimeter_key)
 
         internal_group = (
             self._client.get_group_by_id(internal_group_id) if internal_group_id else {}
@@ -133,21 +153,30 @@ class HcuAlarmControlPanel(HcuHomeBaseEntity, AlarmControlPanelEntity):
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
+        interior_key, perimeter_key = self._zone_keys(
+            self._security_home.get("securityZones", {})
+        )
         await self._async_set_alarm_state(
             AlarmControlPanelState.DISARMED,
-            {"zonesActivation": {"INTERNAL": False, "EXTERNAL": False}},
+            {"zonesActivation": {interior_key: False, perimeter_key: False}},
         )
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
+        interior_key, perimeter_key = self._zone_keys(
+            self._security_home.get("securityZones", {})
+        )
         await self._async_set_alarm_state(
             AlarmControlPanelState.ARMED_HOME,
-            {"zonesActivation": {"INTERNAL": False, "EXTERNAL": True}},
+            {"zonesActivation": {interior_key: False, perimeter_key: True}},
         )
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
+        interior_key, perimeter_key = self._zone_keys(
+            self._security_home.get("securityZones", {})
+        )
         await self._async_set_alarm_state(
             AlarmControlPanelState.ARMED_AWAY,
-            {"zonesActivation": {"INTERNAL": True, "EXTERNAL": True}},
+            {"zonesActivation": {interior_key: True, perimeter_key: True}},
         )

--- a/custom_components/hcu_integration/alarm_control_panel.py
+++ b/custom_components/hcu_integration/alarm_control_panel.py
@@ -78,6 +78,24 @@ class HcuAlarmControlPanel(HcuHomeBaseEntity, AlarmControlPanelEntity):
         )
         return interior_key, perimeter_key
 
+    @staticmethod
+    def _is_legacy_zone_naming(interior_key: str) -> bool:
+        """Pre-1.79 firmware allows INTERNAL+EXTERNAL to be active together (arm away).
+
+        The 1.79+ PRESENCE/ABSENCE naming instead treats the two zones as
+        mutually exclusive modes, so only one is ever active at a time.
+        """
+        return interior_key == _ZONE_INTERIOR_KEYS[0]
+
+    def _zones_activation_payload(
+        self, zones: dict, *, armed_home: bool, armed_away: bool
+    ) -> dict[str, bool]:
+        """Build the zonesActivation payload for the given target arm state."""
+        interior_key, perimeter_key = self._zone_keys(zones)
+        if self._is_legacy_zone_naming(interior_key):
+            return {interior_key: armed_away, perimeter_key: armed_home or armed_away}
+        return {interior_key: armed_away, perimeter_key: armed_home}
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -126,7 +144,16 @@ class HcuAlarmControlPanel(HcuHomeBaseEntity, AlarmControlPanelEntity):
         internal_active = internal_group.get("active", False)
         external_active = external_group.get("active", False)
 
-        if internal_active and external_active:
+        if self._is_legacy_zone_naming(interior_key):
+            if internal_active and external_active:
+                return AlarmControlPanelState.ARMED_AWAY
+            if external_active:
+                return AlarmControlPanelState.ARMED_HOME
+            return AlarmControlPanelState.DISARMED
+
+        # PRESENCE/ABSENCE are mutually exclusive modes: only one zone is
+        # ever active at a time.
+        if internal_active:
             return AlarmControlPanelState.ARMED_AWAY
         if external_active:
             return AlarmControlPanelState.ARMED_HOME
@@ -153,30 +180,24 @@ class HcuAlarmControlPanel(HcuHomeBaseEntity, AlarmControlPanelEntity):
 
     async def async_alarm_disarm(self, code: str | None = None) -> None:
         """Send disarm command."""
-        interior_key, perimeter_key = self._zone_keys(
-            self._security_home.get("securityZones", {})
-        )
+        zones = self._security_home.get("securityZones", {})
+        payload = self._zones_activation_payload(zones, armed_home=False, armed_away=False)
         await self._async_set_alarm_state(
-            AlarmControlPanelState.DISARMED,
-            {"zonesActivation": {interior_key: False, perimeter_key: False}},
+            AlarmControlPanelState.DISARMED, {"zonesActivation": payload}
         )
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command."""
-        interior_key, perimeter_key = self._zone_keys(
-            self._security_home.get("securityZones", {})
-        )
+        zones = self._security_home.get("securityZones", {})
+        payload = self._zones_activation_payload(zones, armed_home=True, armed_away=False)
         await self._async_set_alarm_state(
-            AlarmControlPanelState.ARMED_HOME,
-            {"zonesActivation": {interior_key: False, perimeter_key: True}},
+            AlarmControlPanelState.ARMED_HOME, {"zonesActivation": payload}
         )
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command."""
-        interior_key, perimeter_key = self._zone_keys(
-            self._security_home.get("securityZones", {})
-        )
+        zones = self._security_home.get("securityZones", {})
+        payload = self._zones_activation_payload(zones, armed_home=False, armed_away=True)
         await self._async_set_alarm_state(
-            AlarmControlPanelState.ARMED_AWAY,
-            {"zonesActivation": {interior_key: True, perimeter_key: True}},
+            AlarmControlPanelState.ARMED_AWAY, {"zonesActivation": payload}
         )

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -54,7 +54,7 @@ PLUGIN_FRIENDLY_NAME = {
     "de": "Home Assistant Integration",
     "en": "Home Assistant Integration",
 }
-PLUGIN_VERSION = "2.1.2"
+PLUGIN_VERSION = "2.1.3"
 PLUGIN_DOCUMENTATION_URL = "https://github.com/Ediminator/homematicip-hcu"
 PLUGIN_ISSUE_TRACKER_URL = "https://github.com/Ediminator/homematicip-hcu/issues"
 

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -14,6 +14,6 @@
   "requirements": [
     "aiohttp>=3.0.0"
   ],
-  "version": "2.1.2",
+  "version": "2.1.3",
   "zeroconf": [{"type": "_ssh._tcp.local.", "name": "hcu1*"}]
 }


### PR DESCRIPTION
## Description
HmIP's 1.79 HCU firmware update introduced a new alarm system that renamed the security zone groups used by `setExtendedZonesActivation`: `INTERNAL`/`EXTERNAL` became `PRESENCE`/`ABSENCE`. Arm/disarm requests built with the old names now fail with `HTTP 400 UNKNOWN_GROUP`.

This PR:
- Detects which zone names the HCU currently reports in `securityZones` (`INTERNAL`/`EXTERNAL` on older firmware, `PRESENCE`/`ABSENCE` on 1.79+) and uses those for both reading and setting the alarm state, so the integration keeps working across the firmware rollout.
- On 1.79+ firmware, `PRESENCE`/`ABSENCE` behave as mutually exclusive modes rather than two independently combinable zones. Arm Home/Away now activate only the single matching zone instead of setting both active at once (which caused an inconsistent state in the HmIP app). Pre-1.79 firmware keeps combining both zones for Arm Away as before.
- Bumps the integration version to `2.1.3` and adds a changelog entry.

## Motivation & Context
Fixes #417 — the alarm control panel stopped working for anyone whose HCU received the 1.79 firmware update, since the integration hardcoded the old `INTERNAL`/`EXTERNAL` zone names.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## How Was It Tested?
- [ ] Unit tests
- [x] Manually tested — a community member on 1.79 firmware confirmed via `hcu_integration.send_api_command` that `PRESENCE`/`ABSENCE` are the new working zone names, and that activating both simultaneously (the old Arm Away behavior) shows an inconsistent state in the HmIP app.

Note: I do not have access to a HCU on 1.79 firmware myself, so this fix is based on community testing/confirmation in the issue thread rather than firsthand verification.

## Checklist
- [x] Code follows the project style
- [ ] Tests added
- [x] Documentation updated (CHANGELOG.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_011p5cFyk3VzvALAAmKnpQ2S)_