### PR TITLE
Fix missing "Ignore" option on HCU discovery and add MAC address to device info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 ### 🔧 Fixes & Improvements
 
 - **Missing "Ignore" option on zeroconf discovery** — The zeroconf discovery flow never set a `unique_id`, so Home Assistant's "Ignore" option (which requires a `unique_id`) was unavailable for a discovered HCU, and concurrent discovery flows for the same device could not be deduplicated. The flow now sets its `unique_id` from the device's mDNS hostname. (#419)
-- **HCU MAC address in device info** — The HCU's MAC address is now resolved from the local ARP table (the Homematic IP API itself does not expose it) and stored on the device registry entry, so it shows up in the device's info page like other network devices.
+- **HCU MAC address(es) in device info** — The HCU's MAC address is now resolved from the local ARP table (the Homematic IP API itself does not expose it) and stored on the device registry entry, so it shows up in the device's info page like other network devices. For a HCU reachable over multiple network interfaces (e.g. WLAN and Ethernet), zeroconf is re-queried for all currently known addresses and a MAC connection is registered for each.
 
 ## 2.1.3 - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 ### 🔧 Fixes & Improvements
 
 - **Missing "Ignore" option on zeroconf discovery** — The zeroconf discovery flow never set a `unique_id`, so Home Assistant's "Ignore" option (which requires a `unique_id`) was unavailable for a discovered HCU, and concurrent discovery flows for the same device could not be deduplicated. The flow now sets its `unique_id` from the device's mDNS hostname. (#419)
+- **HCU MAC address in device info** — The HCU's MAC address is now resolved from the local ARP table (the Homematic IP API itself does not expose it) and stored on the device registry entry, so it shows up in the device's info page like other network devices.
 
 ## 2.1.3 - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
+## 2.1.4 - 2026-07-28
+
+### 🔧 Fixes & Improvements
+
+- **Missing "Ignore" option on zeroconf discovery** — The zeroconf discovery flow never set a `unique_id`, so Home Assistant's "Ignore" option (which requires a `unique_id`) was unavailable for a discovered HCU, and concurrent discovery flows for the same device could not be deduplicated. The flow now sets its `unique_id` from the device's mDNS hostname. (#419)
+
 ## 2.1.3 - 2026-07-23
 
 ### 🔧 Fixes & Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
-## 2.1.4 - 2026-07-28
+## 2.1.4 - 2026-07-30
 
 ### 🔧 Fixes & Improvements
 

--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -11,7 +11,9 @@ from functools import partial
 from typing import Any, cast
 
 import getmac
+from zeroconf import IPVersion
 
+from homeassistant.components import zeroconf
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
@@ -31,6 +33,8 @@ from .const import (
     CONF_APP_CLIENT_ID,
     CONF_APP_TOKEN,
     CONF_HCU_SGTIN,
+    CONF_ZEROCONF_NAME,
+    CONF_ZEROCONF_TYPE,
     CONF_PLUGIN_CLIENT_ID,
     CONF_PLUGIN_TOKEN,
     CONF_WEBSOCKET_PORT,
@@ -320,6 +324,31 @@ class HcuCoordinator(DataUpdateCoordinator[set[str]]):
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
+    async def _async_known_hosts(self) -> set[str]:
+        """Return every IPv4 address currently known for the HCU.
+
+        Starts with the configured host and, if the entry was set up via
+        zeroconf, re-queries zeroconf for the service so addresses on other
+        interfaces (e.g. the HCU is reachable over both WLAN and Ethernet)
+        are included too.
+        """
+        hosts: set[str] = set()
+        if host := self.config_entry.data.get(CONF_HOST):
+            hosts.add(host)
+
+        name = self.config_entry.data.get(CONF_ZEROCONF_NAME)
+        type_ = self.config_entry.data.get(CONF_ZEROCONF_TYPE)
+        if name and type_:
+            try:
+                aiozc = await zeroconf.async_get_async_instance(self.hass)
+                info = await aiozc.async_get_service_info(type_, name, timeout=3000)
+            except Exception:  # noqa: BLE001 - best-effort, never block setup on this
+                info = None
+            if info:
+                hosts.update(info.parsed_addresses(IPVersion.V4Only))
+
+        return hosts
+
     async def _register_hcu_device(self) -> None:
         """Register the HCU as a device in Home Assistant."""
         device_registry = dr.async_get(self.hass)
@@ -331,13 +360,14 @@ class HcuCoordinator(DataUpdateCoordinator[set[str]]):
 
         hcu_device = self.client.state.get("devices", {}).get(hcu_device_id, {})
 
-        # The Homematic IP API does not expose the HCU's MAC address, so it is
-        # resolved from the local ARP table via its IP instead. This only
-        # succeeds once the OS has an ARP entry for the host (i.e. after we've
-        # actually talked to it, which is guaranteed at this point).
+        # The Homematic IP API does not expose the HCU's MAC address(es), so
+        # they are resolved from the local ARP table via IP instead. This
+        # only succeeds once the OS has an ARP entry for a given host (i.e.
+        # after we've actually talked to it, which is guaranteed for the
+        # configured host at this point, but not necessarily for other
+        # addresses found via zeroconf).
         connections: set[tuple[str, str]] = set()
-        host = self.config_entry.data.get(CONF_HOST)
-        if host:
+        for host in await self._async_known_hosts():
             try:
                 mac = await self.hass.async_add_executor_job(
                     partial(getmac.get_mac_address, ip=host)

--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -7,7 +7,10 @@ import asyncio
 import logging
 import random
 import json
+from functools import partial
 from typing import Any, cast
+
+import getmac
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
@@ -292,7 +295,7 @@ class HcuCoordinator(DataUpdateCoordinator[set[str]]):
             self._create_setup_issue(str(err))
             return False
 
-        self._register_hcu_device()
+        await self._register_hcu_device()
 
         state = self.client.state
         all_ids = set(state.get("devices", {}).keys()) | set(state.get("groups", {}).keys())
@@ -317,7 +320,7 @@ class HcuCoordinator(DataUpdateCoordinator[set[str]]):
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
-    def _register_hcu_device(self) -> None:
+    async def _register_hcu_device(self) -> None:
         """Register the HCU as a device in Home Assistant."""
         device_registry = dr.async_get(self.hass)
         hcu_device_id = self.client.hcu_device_id
@@ -327,9 +330,30 @@ class HcuCoordinator(DataUpdateCoordinator[set[str]]):
             return
 
         hcu_device = self.client.state.get("devices", {}).get(hcu_device_id, {})
+
+        # The Homematic IP API does not expose the HCU's MAC address, so it is
+        # resolved from the local ARP table via its IP instead. This only
+        # succeeds once the OS has an ARP entry for the host (i.e. after we've
+        # actually talked to it, which is guaranteed at this point).
+        connections: set[tuple[str, str]] = set()
+        host = self.config_entry.data.get(CONF_HOST)
+        if host:
+            try:
+                mac = await self.hass.async_add_executor_job(
+                    partial(getmac.get_mac_address, ip=host)
+                )
+            except Exception:  # noqa: BLE001 - getmac has no documented exception set
+                mac = None
+            # getmac returns the null MAC as a placeholder in some failure
+            # cases; storing it would make Home Assistant treat every device
+            # with the same unresolved lookup as this HCU.
+            if mac and mac != "00:00:00:00:00:00":
+                connections.add((dr.CONNECTION_NETWORK_MAC, dr.format_mac(mac)))
+
         device_registry.async_get_or_create(
             config_entry_id=self.config_entry.entry_id,
             identifiers={(DOMAIN, hcu_device_id)},
+            connections=connections,
             manufacturer=hcu_device.get("oem", "eQ-3"),
             model=hcu_device.get("modelType", "HCU"),
             serial_number=hcu_device.get("id"),

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -55,6 +55,8 @@ from .const import (
     CONF_PLUGIN_TOKEN,
     CONF_PLUGIN_CLIENT_ID,
     CONF_HCU_SGTIN,
+    CONF_ZEROCONF_NAME,
+    CONF_ZEROCONF_TYPE,
     CONF_ENTITY_PREFIX,
     CONF_PLATFORM_OVERRIDES,
     CONF_ADVANCED_DEBUGGING,
@@ -173,6 +175,11 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
 
         self._config_data = {
             CONF_HOST: host,
+            # Recorded so the integration can later re-query zeroconf for all
+            # of the HCU's currently known addresses (e.g. when it's reachable
+            # over both WLAN and Ethernet) and register a MAC for each.
+            CONF_ZEROCONF_NAME: discovery_info.name,
+            CONF_ZEROCONF_TYPE: discovery_info.type,
         }
 
         self.context["title_placeholders"] = {"host": host}

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -163,6 +163,12 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
         if not host:
             return self.async_abort(reason="no_ipv4_address")
 
+        # Setting a unique_id lets Home Assistant deduplicate concurrent
+        # discovery flows for the same device and enables the "Ignore" option,
+        # which is otherwise unavailable for discovery flows without one.
+        await self.async_set_unique_id(discovery_info.hostname)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+
         self._async_abort_entries_match({CONF_HOST: host})
 
         self._config_data = {

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -79,6 +79,11 @@ CONF_WEBSOCKET_PORT = "websocket_port"
 CONF_PLUGIN_TOKEN = "plugin_token"
 CONF_PLUGIN_CLIENT_ID = "plugin_client_id"
 CONF_HCU_SGTIN = "hcu_sgtin"
+# mDNS service name/type recorded from zeroconf discovery. Used to re-query
+# zeroconf for all of the HCU's currently known addresses (e.g. WLAN and
+# Ethernet), so a MAC address connection can be registered for each.
+CONF_ZEROCONF_NAME = "zeroconf_name"
+CONF_ZEROCONF_TYPE = "zeroconf_type"
 CONF_ENTITY_PREFIX = "entity_prefix"
 # Legacy field names — kept only for use in migration code
 CONF_CLIENT_ID = "client_id"

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -54,7 +54,7 @@ PLUGIN_FRIENDLY_NAME = {
     "de": "Home Assistant Integration",
     "en": "Home Assistant Integration",
 }
-PLUGIN_VERSION = "2.1.3"
+PLUGIN_VERSION = "2.1.4"
 PLUGIN_DOCUMENTATION_URL = "https://github.com/Ediminator/homematicip-hcu"
 PLUGIN_ISSUE_TRACKER_URL = "https://github.com/Ediminator/homematicip-hcu/issues"
 

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -5,7 +5,7 @@
     "@Ediminator"
   ],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["zeroconf"],
   "documentation": "https://github.com/Ediminator/homematicip-hcu",
   "integration_type": "hub",
   "iot_class": "local_push",

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -12,7 +12,8 @@
   "issue_tracker": "https://github.com/Ediminator/homematicip-hcu/issues",
   "quality_scale": "silver",
   "requirements": [
-    "aiohttp>=3.0.0"
+    "aiohttp>=3.0.0",
+    "getmac>=0.8.0"
   ],
   "version": "2.1.4",
   "zeroconf": [{"type": "_ssh._tcp.local.", "name": "hcu1*"}]

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -14,6 +14,6 @@
   "requirements": [
     "aiohttp>=3.0.0"
   ],
-  "version": "2.1.3",
+  "version": "2.1.4",
   "zeroconf": [{"type": "_ssh._tcp.local.", "name": "hcu1*"}]
 }


### PR DESCRIPTION
## Description
Two related fixes for the HCU's zeroconf discovery flow, bundled as v2.1.4:

1. **`unique_id` on the discovery flow.** `async_step_zeroconf` in `config_flow.py` never set a `unique_id`, so Home Assistant's "Ignore" option (which requires one) was unavailable for a discovered HCU, and concurrent discovery flows for the same device could not be deduplicated. The flow now sets its `unique_id` from the mDNS hostname before the existing host-based abort check.
2. **HCU MAC address(es) in device info.** The Homematic IP API does not expose a MAC address for any device, including the HCU itself, so it's resolved from the local ARP table via `getmac` instead (the same library Home Assistant core uses for this, e.g. in `samsungtv`). For a HCU reachable over multiple network interfaces (WLAN + Ethernet), the discovered zeroconf service name/type is recorded on the config entry and re-queried at setup to find every currently known address, resolving and registering a MAC connection for each.

## Motivation & Context
Fixes #419. Without a `unique_id`, Home Assistant could not deduplicate concurrent zeroconf discovery flows for the same HCU, so duplicate "Discovered" cards could appear, and the "Ignore" option was unavailable in the three-dot menu. Separately, the HCU's MAC address(es) weren't shown in its device info page since the Homematic IP API doesn't expose one.

## Type of Change
- [x] Bug fix
- [x] New feature

## How Was It Tested?
- [ ] Unit tests
- [ ] Manually tested

`python3.12 -m py_compile` passes on all changed files. `getmac`/`zeroconf` API usage (`get_mac_address`, `async_get_async_instance`, `async_get_service_info`, `IPVersion`) verified against their actual library sources. No hardware available in this environment to trigger a live zeroconf discovery or ARP resolution.

## Checklist
- [x] Code follows the project style
- [ ] Tests added
- [ ] Documentation updated