### PR TITLE
2.2.1: unique plugin ID only in dev mode; fix undeletable user messages from other plugin IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
+## 2.2.1 - 2026-08-08
+
+### 🔧 Fixes & Improvements
+
+- **Unique plugin ID restricted to developer mode** — The per-entry unique plugin ID (letting multiple HA instances pair with the same HCU without colliding on a single plugin identity) is now only generated when re-pairing (Reconfigure/reauth) an entry that has developer mode enabled. Brand-new pairings — where developer mode can't be set yet — and any re-pair without developer mode always use the standard plugin ID. (#423)
+- **Undeletable user messages** — Deleting a user message now retries under both the entry's plugin ID and the standard plugin ID, so a message stays deletable even if it was created before a re-pair changed which plugin ID is active. New user messages are always created under the standard plugin ID. (#423)
+- **Plugin ID shown on HCUweb** — The integration's status page on HCUweb (Config Template) now also shows which plugin ID is currently in use, labeled "(standard)" or "(unique / dev mode)". (#423)
+
 ## 2.2.0 - 2026-08-03
 
 ### 📦 Now available directly in HACS 🥳🥳🥳

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 
 ## 2.2.1 - 2026-08-08
 
-### 🐛 Bug: user messages could become undeletable
+### 🐛 Bug: user messages might not be deletable
 
-Deleting a user message could fail if it was created under a different plugin ID than the one currently active on the entry — the delete request silently didn't remove it, leaving the message stuck.
+If you reconfigured your integration under 2.2.0, please delete all user messages via the `hcu_integration.delete_user_message_request` action.
 
-**Fix:** Deleting a message now retries under both the entry's current plugin ID and the standard plugin ID, and new messages are always created under the standard plugin ID. The integration's status page on HCUweb (Config Template) also now shows which plugin ID is currently in use, labeled "(standard)" or "(unique / dev mode)". (#423)
+Update the integration and perform a reconfiguration for your integration.
 
-**If you paired under 2.2.0:** your entry may still have a random unique plugin ID stored, and keeps using it until you re-pair. To move back to the standard plugin ID, delete any pending user messages first (`delete_user_message_request` service), then open the integration's **Reconfigure** flow and choose to refresh the **Plugin token** (developer mode left disabled, the default).
+Everyone else who doesn't use user messages is not affected.
 
 ## 2.2.0 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 
 ## 2.2.1 - 2026-08-08
 
+### ⚠️ Note for installations paired under 2.2.0
+
+If you paired (or re-paired) while on 2.2.0, your entry already has a random per-entry plugin ID stored and keeps using it — it's tied to the currently issued auth token, so it doesn't change on its own. To fully move back to the standard plugin ID:
+
+1. **Delete any pending user messages first** (`delete_user_message_request` service), if you have any — do this before re-pairing.
+2. Open the integration's **Reconfigure** flow and choose to refresh the **Plugin token** (with developer mode left disabled, the default). This requests a new auth token under the standard plugin ID and drops the stored unique one.
+
 ### 🔧 Fixes & Improvements
 
 - **Unique plugin ID restricted to developer mode** — The per-entry unique plugin ID (letting multiple HA instances pair with the same HCU without colliding on a single plugin identity) is now only generated when re-pairing (Reconfigure/reauth) an entry that has developer mode enabled. Brand-new pairings — where developer mode can't be set yet — and any re-pair without developer mode always use the standard plugin ID. (#423)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,11 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 
 ### 🐛 Bug: user messages could become undeletable
 
-Deleting a user message always used the entry's *current* plugin ID — but a message's creation and the plugin ID later active on that entry can drift apart (most commonly on an entry that got a random per-entry plugin ID under 2.2.0). If a message was created under a plugin ID that no longer matched, the delete request silently failed to remove it, leaving it stuck.
+Deleting a user message could fail if it was created under a different plugin ID than the one currently active on the entry — the delete request silently didn't remove it, leaving the message stuck.
 
-**Fix:** New user messages are now always created under the standard plugin ID, and deleting a message retries under both the entry's current plugin ID and the standard plugin ID — so it stays deletable either way. (#423)
+**Fix:** Deleting a message now retries under both the entry's current plugin ID and the standard plugin ID, and new messages are always created under the standard plugin ID. The integration's status page on HCUweb (Config Template) also now shows which plugin ID is currently in use, labeled "(standard)" or "(unique / dev mode)". (#423)
 
-### 🔌 About the plugin ID
-
-The underlying cause was the per-entry *unique* plugin ID (`PLUGIN_ID` + a random suffix), originally introduced so multiple HA instances could pair with the same HCU without colliding on one shared plugin identity. It was generated for every new pairing, which most installations never needed and which made the plugin ID unexpectedly not match the documented `PLUGIN_ID`.
-
-- **Plugin ID shown on HCUweb** — the integration's status page on HCUweb (Config Template) now shows which plugin ID is currently in use, labeled "(standard)" or "(unique / dev mode)". (#423)
-
-**If you paired under 2.2.0**, your entry may already have a random unique plugin ID stored, and keeps using it until you re-pair — it's tied to the currently issued auth token and doesn't change on its own. To fully move back to the standard plugin ID: delete any pending user messages first (`delete_user_message_request` service), then open the integration's **Reconfigure** flow and choose to refresh the **Plugin token** (developer mode left disabled, the default).
+**If you paired under 2.2.0:** your entry may still have a random unique plugin ID stored, and keeps using it until you re-pair. To move back to the standard plugin ID, delete any pending user messages first (`delete_user_message_request` service), then open the integration's **Reconfigure** flow and choose to refresh the **Plugin token** (developer mode left disabled, the default).
 
 ## 2.2.0 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,20 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 
 ## 2.2.1 - 2026-08-08
 
-### ⚠️ Note for installations paired under 2.2.0
+### 🐛 Bug: user messages could become undeletable
 
-If you paired (or re-paired) while on 2.2.0, your entry already has a random per-entry plugin ID stored and keeps using it — it's tied to the currently issued auth token, so it doesn't change on its own. To fully move back to the standard plugin ID:
+Deleting a user message always used the entry's *current* plugin ID — but a message's creation and the plugin ID later active on that entry can drift apart (most commonly on an entry that got a random per-entry plugin ID under 2.2.0). If a message was created under a plugin ID that no longer matched, the delete request silently failed to remove it, leaving it stuck.
 
-1. **Delete any pending user messages first** (`delete_user_message_request` service), if you have any — do this before re-pairing.
-2. Open the integration's **Reconfigure** flow and choose to refresh the **Plugin token** (with developer mode left disabled, the default). This requests a new auth token under the standard plugin ID and drops the stored unique one.
+**Fix:** New user messages are now always created under the standard plugin ID, and deleting a message retries under both the entry's current plugin ID and the standard plugin ID — so it stays deletable either way. (#423)
 
-### 🔧 Fixes & Improvements
+### 🔌 About the plugin ID
 
-- **Unique plugin ID restricted to developer mode** — The per-entry unique plugin ID (letting multiple HA instances pair with the same HCU without colliding on a single plugin identity) is now only generated when re-pairing (Reconfigure/reauth) an entry that has developer mode enabled. Brand-new pairings — where developer mode can't be set yet — and any re-pair without developer mode always use the standard plugin ID. (#423)
-- **Undeletable user messages** — Deleting a user message now retries under both the entry's plugin ID and the standard plugin ID, so a message stays deletable even if it was created before a re-pair changed which plugin ID is active. New user messages are always created under the standard plugin ID. (#423)
-- **Plugin ID shown on HCUweb** — The integration's status page on HCUweb (Config Template) now also shows which plugin ID is currently in use, labeled "(standard)" or "(unique / dev mode)". (#423)
+The underlying cause was the per-entry *unique* plugin ID (`PLUGIN_ID` + a random suffix), originally introduced so multiple HA instances could pair with the same HCU without colliding on one shared plugin identity. It was generated for every new pairing, which most installations never needed and which made the plugin ID unexpectedly not match the documented `PLUGIN_ID`.
+
+- **Unique plugin ID restricted to developer mode** — it's now only generated when re-pairing (Reconfigure/reauth) an entry that has developer mode enabled. Brand-new pairings — where developer mode can't be set yet — and any re-pair without developer mode always use the standard plugin ID. (#423)
+- **Plugin ID shown on HCUweb** — the integration's status page on HCUweb (Config Template) now shows which plugin ID is currently in use, labeled "(standard)" or "(unique / dev mode)". (#423)
+
+**If you paired under 2.2.0**, your entry may already have a random unique plugin ID stored, and keeps using it until you re-pair — it's tied to the currently issued auth token and doesn't change on its own. To fully move back to the standard plugin ID: delete any pending user messages first (`delete_user_message_request` service), then open the integration's **Reconfigure** flow and choose to refresh the **Plugin token** (developer mode left disabled, the default).
 
 ## 2.2.0 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ Deleting a user message always used the entry's *current* plugin ID — but a me
 
 The underlying cause was the per-entry *unique* plugin ID (`PLUGIN_ID` + a random suffix), originally introduced so multiple HA instances could pair with the same HCU without colliding on one shared plugin identity. It was generated for every new pairing, which most installations never needed and which made the plugin ID unexpectedly not match the documented `PLUGIN_ID`.
 
-- **Unique plugin ID restricted to developer mode** — it's now only generated when re-pairing (Reconfigure/reauth) an entry that has developer mode enabled. Brand-new pairings — where developer mode can't be set yet — and any re-pair without developer mode always use the standard plugin ID. (#423)
 - **Plugin ID shown on HCUweb** — the integration's status page on HCUweb (Config Template) now shows which plugin ID is currently in use, labeled "(standard)" or "(unique / dev mode)". (#423)
 
 **If you paired under 2.2.0**, your entry may already have a random unique plugin ID stored, and keeps using it until you re-pair — it's tied to the currently issued auth token and doesn't change on its own. To fully move back to the standard plugin ID: delete any pending user messages first (`delete_user_message_request` service), then open the integration's **Reconfigure** flow and choose to refresh the **Plugin token** (developer mode left disabled, the default).

--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -135,6 +135,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Homematic IP Local (HCU) from a config entry."""
+    # CONF_UNIQUE_PLUGIN_ID is only ever set while re-pairing with developer
+    # mode enabled (see const.py); every other entry falls back to PLUGIN_ID.
     plugin_id = entry.data.get(CONF_UNIQUE_PLUGIN_ID) or PLUGIN_ID
 
     client = HcuApiClient(

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -1113,14 +1113,19 @@ class HcuApiClient:
 
     async def async_delete_user_message_request(self, user_message_id: str) -> None:
         """Delete User Message Request."""
-        # See async_create_user_message_request: always the plain PLUGIN_ID.
-        message = {
-            "id": str(uuid4()),
-            "pluginId": PLUGIN_ID,
-            "type": "DELETE_USER_MESSAGE_REQUEST",
-            "body": {"userMessageId": user_message_id},
-        }
-        await self._send_message(message)
+        # We always create user messages under the plain PLUGIN_ID (see
+        # async_create_user_message_request), but older messages may still
+        # exist under this entry's unique per-pairing plugin id. Send the
+        # delete once per distinct id so it's removed either way; de-duped
+        # so entries without a unique suffix don't send the same request twice.
+        for plugin_id in dict.fromkeys((self.plugin_id, PLUGIN_ID)):
+            message = {
+                "id": str(uuid4()),
+                "pluginId": plugin_id,
+                "type": "DELETE_USER_MESSAGE_REQUEST",
+                "body": {"userMessageId": user_message_id},
+            }
+            await self._send_message(message)
         
     async def async_group_control(
         self, path: str, group_id: str, body: dict[str, Any] | None = None

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -850,13 +850,25 @@ class HcuApiClient:
                 "groupId": "info",
                 "order": 2,
             },
+            "plugin_id": {
+                "friendlyName": "Plugin ID",
+                "description": "Plugin ID used for this pairing — unique per entry in developer mode, otherwise the standard plugin ID",
+                "dataType": "READONLY",
+                "currentValue": (
+                    f"{self.plugin_id} (unique / dev mode)"
+                    if self.plugin_id != PLUGIN_ID
+                    else f"{self.plugin_id} (standard)"
+                ),
+                "groupId": "info",
+                "order": 3,
+            },
             "device_count": {
                 "friendlyName": "Devices",
                 "description": "Number of Homematic IP devices managed by this integration",
                 "dataType": "READONLY",
                 "currentValue": str(device_count),
                 "groupId": "info",
-                "order": 3,
+                "order": 4,
             },
             "documentation": {
                 "friendlyName": "Documentation",

--- a/custom_components/hcu_integration/api.py
+++ b/custom_components/hcu_integration/api.py
@@ -1099,9 +1099,13 @@ class HcuApiClient:
     
     async def async_create_user_message_request(self, body: dict[str, Any]) -> None:
         """Create User Message Request."""
+        # User messages always use the plain PLUGIN_ID, never the per-entry
+        # unique variant (PLUGIN_ID + random pairing suffix): the HCU/app
+        # associates user messages with the base plugin identity regardless
+        # of which config entry paired with the random suffix.
         message = {
             "id": str(uuid4()),
-            "pluginId": self.plugin_id,
+            "pluginId": PLUGIN_ID,
             "type": "CREATE_USER_MESSAGE_REQUEST",
             "body": body,
         }
@@ -1109,9 +1113,10 @@ class HcuApiClient:
 
     async def async_delete_user_message_request(self, user_message_id: str) -> None:
         """Delete User Message Request."""
+        # See async_create_user_message_request: always the plain PLUGIN_ID.
         message = {
             "id": str(uuid4()),
-            "pluginId": self.plugin_id,
+            "pluginId": PLUGIN_ID,
             "type": "DELETE_USER_MESSAGE_REQUEST",
             "body": {"userMessageId": user_message_id},
         }

--- a/custom_components/hcu_integration/config_flow.py
+++ b/custom_components/hcu_integration/config_flow.py
@@ -231,14 +231,12 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Choose which connections to set up: App User, Plugin User, or both."""
         errors: dict[str, str] = {}
-        # New entries get a plugin ID unique to this entry so multiple HA instances
-        # can pair with the same HCU without colliding on one shared plugin identity.
-        # The suffix must be decided now (not derived from the entry ID, which
-        # doesn't exist yet) because it has to be used in the auth token request
-        # below and stay identical for every later connection/message on this token.
-        self._config_data.setdefault(
-            CONF_UNIQUE_PLUGIN_ID, f"{PLUGIN_ID}.{uuid.uuid4().hex[:6]}"
-        )
+        # Brand-new entries always pair under the plain PLUGIN_ID. The unique
+        # per-entry variant (PLUGIN_ID + random suffix, letting multiple HA
+        # instances pair with the same HCU without colliding on one shared
+        # plugin identity) is a developer-mode-only feature — it can only be
+        # opted into later, via reconfigure, once the entry (and its dev
+        # option) exists. See async_step_reconfigure_auth.
 
         if user_input is not None:
             use_app = user_input.get("use_app_user", False)
@@ -562,11 +560,18 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
             session = aiohttp_client.async_get_clientsession(self.hass)
             ssl_context = await create_unverified_ssl_context(self.hass)
 
-            # A new activation key means a brand-new plugin authorization, so it
-            # gets its own unique plugin ID too — same reasoning as new entries
-            # (see async_step_auth_type_selection): it must be decided before the
-            # auth token request and stay identical afterwards.
-            self._config_data[CONF_UNIQUE_PLUGIN_ID] = f"{PLUGIN_ID}.{uuid.uuid4().hex[:6]}"
+            entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+            dev = entry.options.get(CONF_DEV, DEFAULT_DEV) if entry else DEFAULT_DEV
+
+            # A new activation key means a brand-new plugin authorization. The
+            # unique per-entry plugin ID (PLUGIN_ID + random suffix) is only
+            # generated when this entry has developer mode enabled — everyone
+            # else re-pairs under the plain PLUGIN_ID. Must be decided before
+            # the auth token request and stay identical afterwards.
+            if dev:
+                self._config_data[CONF_UNIQUE_PLUGIN_ID] = f"{PLUGIN_ID}.{uuid.uuid4().hex[:6]}"
+            else:
+                self._config_data.pop(CONF_UNIQUE_PLUGIN_ID, None)
 
             try:
                 new_token = await self._async_get_auth_token(
@@ -576,15 +581,17 @@ class HcuConfigFlow(ConfigFlow, domain=DOMAIN):
                     session, host, HCU_REST_PORT, activation_key, new_token, ssl_context
                 )
 
-                entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
                 updated_data = {
                     **entry.data,
                     CONF_HOST: self._config_data[CONF_HOST],
                     CONF_PLUGIN_TOKEN: new_token,
                     CONF_PLUGIN_CLIENT_ID: new_client_id,
                     CONF_AUTH_TYPE: AUTH_TYPE_DUAL if self._is_dual_setup else AUTH_TYPE_PLUGIN,
-                    CONF_UNIQUE_PLUGIN_ID: self._config_data[CONF_UNIQUE_PLUGIN_ID],
                 }
+                if dev:
+                    updated_data[CONF_UNIQUE_PLUGIN_ID] = self._config_data[CONF_UNIQUE_PLUGIN_ID]
+                else:
+                    updated_data.pop(CONF_UNIQUE_PLUGIN_ID, None)
                 if self._is_dual_setup:
                     updated_data[CONF_APP_TOKEN] = self._config_data.get(CONF_APP_TOKEN, "")
                     updated_data[CONF_HCU_SGTIN] = self._config_data.get(CONF_HCU_SGTIN, "")

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -54,7 +54,7 @@ PLUGIN_FRIENDLY_NAME = {
     "de": "Home Assistant Integration",
     "en": "Home Assistant Integration",
 }
-PLUGIN_VERSION = "2.2.0"
+PLUGIN_VERSION = "2.2.1"
 PLUGIN_DOCUMENTATION_URL = "https://github.com/Ediminator/homematicip-hcu"
 PLUGIN_ISSUE_TRACKER_URL = "https://github.com/Ediminator/homematicip-hcu/issues"
 

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -85,11 +85,14 @@ CONF_HCU_SGTIN = "hcu_sgtin"
 CONF_ZEROCONF_NAME = "zeroconf_name"
 CONF_ZEROCONF_TYPE = "zeroconf_type"
 CONF_ENTITY_PREFIX = "entity_prefix"
-# New config entries generate their own unique plugin ID (PLUGIN_ID + a random
-# 6-char suffix, decided once during pairing since it must match what was sent
-# in the auth token request) so multiple HA instances can pair with the same HCU
-# without colliding on a single shared plugin identity. Purely additive: older
-# entries simply don't have this key, and every read site falls back to the
+# Opt-in, developer-mode-only (see CONF_DEV): while re-pairing (reconfigure/
+# reauth) with dev mode enabled, the entry gets its own unique plugin ID
+# (PLUGIN_ID + a random 6-char suffix, decided once since it must match what
+# was sent in the auth token request) so multiple HA instances can pair with
+# the same HCU without colliding on a single shared plugin identity. Everyone
+# else — including every brand-new pairing, where dev mode can't yet be set —
+# stays on the plain PLUGIN_ID. Purely additive: entries without dev mode
+# enabled simply don't have this key, and every read site falls back to the
 # plain PLUGIN_ID via `... or PLUGIN_ID` — no config entry version bump or
 # migration needed, so downgrading the integration afterwards is unaffected.
 CONF_UNIQUE_PLUGIN_ID = "unique_plugin_id"

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -15,6 +15,6 @@
     "aiohttp>=3.0.0",
     "getmac>=0.8.0"
   ],
-  "version": "2.2.0",
+  "version": "2.2.1",
   "zeroconf": [{"type": "_ssh._tcp.local.", "name": "hcu1*"}]
 }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -594,8 +594,42 @@ async def test_async_create_user_message_request_uses_plain_plugin_id(hass: Home
     assert sent_message["body"] == body
 
 
-async def test_async_delete_user_message_request_uses_plain_plugin_id(hass: HomeAssistant):
-    """Deleting a user message must also use the plain PLUGIN_ID."""
+async def test_async_delete_user_message_request_sends_for_unique_and_plain_plugin_id(
+    hass: HomeAssistant,
+):
+    """Deleting a user message must try both the unique and plain PLUGIN_ID.
+
+    The message may have been created under either identity, so both delete
+    requests need to go out when the entry has a unique per-pairing id.
+    """
+    from custom_components.hcu_integration.const import PLUGIN_ID
+
+    unique_plugin_id = f"{PLUGIN_ID}-ab12cd"
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = HcuApiClient(
+        hass=hass,
+        host="192.168.1.100",
+        auth_token="test-token",
+        session=session,
+        plugin_id=unique_plugin_id,
+    )
+
+    with patch.object(client, "_send_message", new_callable=AsyncMock) as mock_send:
+        await client.async_delete_user_message_request(user_message_id="msg-1")
+
+    assert mock_send.call_count == 2
+    sent_plugin_ids = [call.args[0]["pluginId"] for call in mock_send.call_args_list]
+    assert sent_plugin_ids == [unique_plugin_id, PLUGIN_ID]
+    for call in mock_send.call_args_list:
+        sent_message = call.args[0]
+        assert sent_message["type"] == "DELETE_USER_MESSAGE_REQUEST"
+        assert sent_message["body"] == {"userMessageId": "msg-1"}
+
+
+async def test_async_delete_user_message_request_dedupes_when_ids_match(
+    hass: HomeAssistant,
+):
+    """No unique suffix configured: only one delete request should be sent."""
     from custom_components.hcu_integration.const import PLUGIN_ID
 
     session = MagicMock(spec=aiohttp.ClientSession)
@@ -604,8 +638,8 @@ async def test_async_delete_user_message_request_uses_plain_plugin_id(hass: Home
         host="192.168.1.100",
         auth_token="test-token",
         session=session,
-        plugin_id=f"{PLUGIN_ID}-ab12cd",
     )
+    assert client.plugin_id == PLUGIN_ID
 
     with patch.object(client, "_send_message", new_callable=AsyncMock) as mock_send:
         await client.async_delete_user_message_request(user_message_id="msg-1")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -568,3 +568,50 @@ async def test_async_set_switch_state(
             channel_index,
             expected_body
         )
+
+
+async def test_async_create_user_message_request_uses_plain_plugin_id(hass: HomeAssistant):
+    """User messages must use the plain PLUGIN_ID, not a per-entry unique variant."""
+    from custom_components.hcu_integration.const import PLUGIN_ID
+
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = HcuApiClient(
+        hass=hass,
+        host="192.168.1.100",
+        auth_token="test-token",
+        session=session,
+        plugin_id=f"{PLUGIN_ID}-ab12cd",
+    )
+
+    body = {"title": {"en": "Hi"}, "message": {"en": "Hello"}}
+    with patch.object(client, "_send_message", new_callable=AsyncMock) as mock_send:
+        await client.async_create_user_message_request(body=body)
+
+    mock_send.assert_called_once()
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["pluginId"] == PLUGIN_ID
+    assert sent_message["type"] == "CREATE_USER_MESSAGE_REQUEST"
+    assert sent_message["body"] == body
+
+
+async def test_async_delete_user_message_request_uses_plain_plugin_id(hass: HomeAssistant):
+    """Deleting a user message must also use the plain PLUGIN_ID."""
+    from custom_components.hcu_integration.const import PLUGIN_ID
+
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = HcuApiClient(
+        hass=hass,
+        host="192.168.1.100",
+        auth_token="test-token",
+        session=session,
+        plugin_id=f"{PLUGIN_ID}-ab12cd",
+    )
+
+    with patch.object(client, "_send_message", new_callable=AsyncMock) as mock_send:
+        await client.async_delete_user_message_request(user_message_id="msg-1")
+
+    mock_send.assert_called_once()
+    sent_message = mock_send.call_args[0][0]
+    assert sent_message["pluginId"] == PLUGIN_ID
+    assert sent_message["type"] == "DELETE_USER_MESSAGE_REQUEST"
+    assert sent_message["body"] == {"userMessageId": "msg-1"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -649,3 +649,37 @@ async def test_async_delete_user_message_request_dedupes_when_ids_match(
     assert sent_message["pluginId"] == PLUGIN_ID
     assert sent_message["type"] == "DELETE_USER_MESSAGE_REQUEST"
     assert sent_message["body"] == {"userMessageId": "msg-1"}
+
+
+async def test_config_template_response_shows_standard_plugin_id(api_client: HcuApiClient):
+    """The HCUweb config template must report the standard plugin ID as such."""
+    from custom_components.hcu_integration.const import PLUGIN_ID
+
+    with patch.object(api_client, "_send_message", new_callable=AsyncMock) as mock_send:
+        await api_client._send_config_template_response("template-1")
+
+    sent_message = mock_send.call_args[0][0]
+    plugin_id_property = sent_message["body"]["properties"]["plugin_id"]
+    assert plugin_id_property["currentValue"] == f"{PLUGIN_ID} (standard)"
+
+
+async def test_config_template_response_shows_unique_plugin_id(hass: HomeAssistant):
+    """The HCUweb config template must flag a dev-mode unique plugin ID as such."""
+    from custom_components.hcu_integration.const import PLUGIN_ID
+
+    unique_plugin_id = f"{PLUGIN_ID}.ab12cd"
+    session = MagicMock(spec=aiohttp.ClientSession)
+    client = HcuApiClient(
+        hass=hass,
+        host="192.168.1.100",
+        auth_token="test-token",
+        session=session,
+        plugin_id=unique_plugin_id,
+    )
+
+    with patch.object(client, "_send_message", new_callable=AsyncMock) as mock_send:
+        await client._send_config_template_response("template-2")
+
+    sent_message = mock_send.call_args[0][0]
+    plugin_id_property = sent_message["body"]["properties"]["plugin_id"]
+    assert plugin_id_property["currentValue"] == f"{unique_plugin_id} (unique / dev mode)"


### PR DESCRIPTION
## Description
Version bump to **2.2.1** with three related fixes around the per-entry unique plugin ID (`PLUGIN_ID` + a random pairing suffix, used so multiple HA instances can pair with the same HCU without colliding on one shared plugin identity):

1. **User messages sent under the "wrong" plugin ID couldn't be deleted.** `async_create_user_message_request` now always creates messages under the plain `PLUGIN_ID`. `async_delete_user_message_request` now sends `DELETE_USER_MESSAGE_REQUEST` once per distinct plugin ID (the entry's unique ID, if any, and the plain `PLUGIN_ID`), de-duped so entries without a unique suffix only send one request. This ensures a message can always be deleted regardless of which identity it was originally created under.
2. **The unique plugin ID is now developer-mode only.** Previously every new pairing generated its own unique plugin ID. Now:
   - A brand-new pairing (`async_step_auth_type_selection`) always uses the plain `PLUGIN_ID` — developer mode can't be set yet at that point since the config entry doesn't exist.
   - Re-pairing an existing entry (`async_step_reconfigure_auth`, used by both "Reconfigure" and reauth) only generates a new unique plugin ID if that entry has developer mode (`CONF_DEV`) enabled; otherwise it explicitly clears `CONF_UNIQUE_PLUGIN_ID` so the entry falls back to the plain `PLUGIN_ID`.
   - `async_setup_entry` and all other read sites are unaffected — they already fell back to `PLUGIN_ID` via `... or PLUGIN_ID`.
3. **The HCUweb config template now shows which plugin ID is in use.** Previously it only reported the integration version. It now also shows the plugin ID this pairing is currently using, labeled `(standard)` or `(unique / dev mode)`, so it's clear at a glance without digging through diagnostics.

Also bumps `manifest.json`/`PLUGIN_VERSION` to `2.2.1` and adds the corresponding `CHANGELOG.md` entry.

## Motivation & Context
The unique-per-entry plugin ID is a niche feature for advanced users running multiple HA instances against the same HCU. For everyone else it added a discoverability/support cost (a plugin ID that doesn't match the documented `PLUGIN_ID`) with no upside, and it caused a real bug: because the auth token is bound to whichever plugin ID it was requested with, a user message created before a re-pair (or under a different HA instance's unique ID) could no longer be deleted once the client's `plugin_id` changed. Gating the unique ID behind developer mode, always trying both IDs on delete, and surfacing the active plugin ID on HCUweb fixes the bug and makes the behavior transparent.

## Type of Change
- [x] Bug fix

## How Was It Tested?
- [x] Unit tests — added/updated in `tests/test_api.py` covering `async_create_user_message_request`, `async_delete_user_message_request` (single-ID and dual-ID/dedup cases), and the new plugin ID field in the config template response. Verified via `ast.parse` in this environment since `pytest-homeassistant-custom-component` could not be installed in the sandbox (pre-existing Bluetooth/build-dependency resolution issue, unrelated to this change).
- [ ] Manually tested

## Checklist
- [x] Code follows the project style
- [x] Tests added
- [x] Documentation updated (`CHANGELOG.md`)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR limits unique plugin IDs to developer-mode re-pairing, retries user-message deletion across distinct plugin IDs, exposes the active plugin ID in the HCUweb template, and bumps the integration to 2.2.1.
- New pairings use the standard plugin identity, while developer-mode reconfiguration can generate a unique identity.
- User-message creation uses the standard ID and deletion attempts both the active and standard IDs.
- The configuration template reports the active plugin identity and its mode.
- Tests cover user-message request identities, deletion deduplication, and template output.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because developer-mode user-message requests still use a plugin identity that differs from the authenticated token and WebSocket identity.

The previously reported identity mismatch remains: developer-mode clients authenticate as their unique `self.plugin_id`, while creation and one deletion attempt still place the plain `PLUGIN_ID` in the request body, allowing those operations to be rejected or misrouted.

**Files Needing Attention:** custom_components/hcu_integration/api.py
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| custom_components/hcu_integration/api.py | Changes user-message request identities and adds the active plugin ID to the configuration template. |
| custom_components/hcu_integration/config_flow.py | Restricts unique plugin ID generation to developer-mode reconfiguration and clears it otherwise. |
| tests/test_api.py | Adds focused coverage for user-message plugin IDs, deletion deduplication, and configuration-template identity labels. |
| custom_components/hcu_integration/const.py | Updates the integration version and documents the developer-mode-only unique plugin ID behavior. |
| custom_components/hcu_integration/manifest.json | Bumps the published integration version to 2.2.1. |

</details>

<sub>Reviews (7): Last reviewed commit: ["Changelog: rewrite user-message bug note..."](https://github.com/ediminator/homematicip-hcu/commit/35365e8e09cc78f3de6db6567d91b9c57a2a8710) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51430482)</sub>

<!-- /greptile_comment -->