### PR TITLE
feat: add distance/height sensors for ELV-SH-DUSI (fixes #427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
+## 2.2.2 - 2026-08-26
+
+### 🔧 Fixes & Improvements
+
+- **Missing sensors for ELV-SH-DUSI** — The ultrasonic distance sensor interface reported its values correctly to the HCU, but the integration had no mapping for its channel fields, so they only showed up in the diagnostics export instead of as regular entities. Added `distance` and `calculatedHeight` as sensors, and `referenceHeight` (the configured calibration value) as a diagnostic sensor. (#427)
+
 ## 2.2.1 - 2026-08-08
 
 ### 🐛 Bug: user messages might not be deletable

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -1003,6 +1003,25 @@ HMIP_FEATURE_TO_ENTITY = {
         "device_class": SensorDeviceClass.MOISTURE,
         "state_class": SensorStateClass.MEASUREMENT,
     },
+    # Ultrasonic distance sensor interface (e.g. ELV-SH-DUSI) - Issue #427
+    "distance": {
+        "class": "HcuGenericSensor",
+        "name": "Distance",
+        "unit": UnitOfLength.METERS,
+        "device_class": SensorDeviceClass.DISTANCE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "suggested_display_precision": 2,
+        "icon": "mdi:signal-distance-variant",
+    },
+    "calculatedHeight": {
+        "class": "HcuGenericSensor",
+        "name": "Calculated Height",
+        "unit": UnitOfLength.METERS,
+        "device_class": SensorDeviceClass.DISTANCE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "suggested_display_precision": 2,
+        "icon": "mdi:arrow-expand-vertical",
+    },
     "carrierSense": {
         "class": "HcuHomeSensor",
         "name": "Radio Traffic",

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -1003,24 +1003,36 @@ HMIP_FEATURE_TO_ENTITY = {
         "device_class": SensorDeviceClass.MOISTURE,
         "state_class": SensorStateClass.MEASUREMENT,
     },
-    # Ultrasonic distance sensor interface (e.g. ELV-SH-DUSI) - Issue #427
+    # Ultrasonic distance sensor interface (ELV-SH-DUSI, DISTANCE_SENSOR_CHANNEL) - Issue #427
+    # Raw values from the HCU are in centimeters, e.g. distance=25.2,
+    # calculatedHeight=149.8, referenceHeight=175.0 (referenceHeight - distance == calculatedHeight).
     "distance": {
         "class": "HcuGenericSensor",
         "name": "Distance",
-        "unit": UnitOfLength.METERS,
+        "unit": UnitOfLength.CENTIMETERS,
         "device_class": SensorDeviceClass.DISTANCE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "suggested_display_precision": 2,
+        "suggested_display_precision": 1,
         "icon": "mdi:signal-distance-variant",
     },
     "calculatedHeight": {
         "class": "HcuGenericSensor",
         "name": "Calculated Height",
-        "unit": UnitOfLength.METERS,
+        "unit": UnitOfLength.CENTIMETERS,
         "device_class": SensorDeviceClass.DISTANCE,
         "state_class": SensorStateClass.MEASUREMENT,
-        "suggested_display_precision": 2,
+        "suggested_display_precision": 1,
         "icon": "mdi:arrow-expand-vertical",
+    },
+    "referenceHeight": {
+        "class": "HcuGenericSensor",
+        "name": "Reference Height",
+        "unit": UnitOfLength.CENTIMETERS,
+        "device_class": SensorDeviceClass.DISTANCE,
+        "state_class": SensorStateClass.MEASUREMENT,
+        "suggested_display_precision": 1,
+        "icon": "mdi:arrow-expand-vertical",
+        "entity_category": EntityCategory.DIAGNOSTIC,
     },
     "carrierSense": {
         "class": "HcuHomeSensor",

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -54,7 +54,7 @@ PLUGIN_FRIENDLY_NAME = {
     "de": "Home Assistant Integration",
     "en": "Home Assistant Integration",
 }
-PLUGIN_VERSION = "2.2.1"
+PLUGIN_VERSION = "2.2.2"
 PLUGIN_DOCUMENTATION_URL = "https://github.com/Ediminator/homematicip-hcu"
 PLUGIN_ISSUE_TRACKER_URL = "https://github.com/Ediminator/homematicip-hcu/issues"
 

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -15,6 +15,6 @@
     "aiohttp>=3.0.0",
     "getmac>=0.8.0"
   ],
-  "version": "2.2.1",
+  "version": "2.2.2",
   "zeroconf": [{"type": "_ssh._tcp.local.", "name": "hcu1*"}]
 }


### PR DESCRIPTION
## Description
Adds the missing `distance`, `calculatedHeight`, and `referenceHeight` fields of the ELV-SH-DUSI ultrasonic distance sensor interface (`DISTANCE_SENSOR_CHANNEL`) to `HMIP_FEATURE_TO_ENTITY` in `const.py`, so they show up as proper Home Assistant sensor entities instead of only being visible in the diagnostics export.

- `distance` — raw measured distance to the target (regular sensor)
- `calculatedHeight` — computed fill/height value (regular sensor)
- `referenceHeight` — the configured calibration value the height calculation is based on (diagnostic sensor, since `referenceHeight - distance == calculatedHeight`)

All three use `SensorDeviceClass.DISTANCE` with `UnitOfLength.CENTIMETERS`, verified against the reporter's diagnostics export (raw values are centimeters, e.g. `distance: 25.2`, `calculatedHeight: 149.8`, `referenceHeight: 175.0`).

No `translation_key` was set for these entities, consistent with the majority of existing `HMIP_FEATURE_TO_ENTITY` entries (e.g. `soilMoisture`, `airPressure`) — no changes needed in `translations/*.json` or `icons.json`.

## Motivation & Context
Fixes #427 — the ELV-SH-DUSI reports correct values to the HCU, but the integration had no mapping for its channel fields, so no sensor entities were created for it at all.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## How Was It Tested?
- [ ] Unit tests
- [x] Manually tested

Verified the channel data and units against the reporter's attached diagnostics JSON (`functionalChannelType: DISTANCE_SENSOR_CHANNEL`, device type `ULTRASONIC_DISTANCE_SENSOR`). Not tested against a physical DUSI device — the reporter has been asked to confirm on hardware.

## Checklist
- [x] Code follows the project style (`ruff check`/`ruff format --diff` clean on the changed lines; no new warnings introduced)
- [ ] Tests added
- [ ] Documentation updated

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012b7mfkW2tF9u6zTzkEgbzR)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds Home Assistant sensor mappings for the ELV-SH-DUSI ultrasonic distance interface and releases the integration as version 2.2.2.
- Exposes distance and calculated height as centimeter measurement sensors.
- Exposes reference height as a diagnostic centimeter measurement sensor.
- Updates the manifest version and changelog.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified.

The new mappings use metadata already supported by the generic sensor implementation, and the integration, plugin, and changelog versions remain aligned.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/hcu_integration/const.py | Adds three internally consistent generic distance-sensor mappings and updates the plugin version. |
| custom_components/hcu_integration/manifest.json | Updates the integration version from 2.2.1 to 2.2.2, aligned with the plugin constant and changelog. |
| CHANGELOG.md | Documents the newly exposed ELV-SH-DUSI distance and height sensors in the 2.2.2 release. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump version to 2.2.2, add change..."](https://github.com/ediminator/homematicip-hcu/commit/12c0881375f23eca832669f22a4573a32b53651e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56958686)</sub>

<!-- /greptile_comment -->