### PR TITLE
Add DOOR_SENSOR channelRole support via HcuDoorBinarySensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,9 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 
 ## 2.2.2 - 2026-08-26
 
-### ✨ New Feature: Door contact support (`DOOR_SENSOR` channelRole)
+### ✨ New Features
 
-- Added a dedicated `HcuDoorBinarySensor` for channels reporting the `DOOR_SENSOR` channelRole. Previously only `WINDOW_SENSOR` had a mapping, so door contacts configured with this role had no entity created at all. The new binary sensor gets `device_class: door`, is named "Door", and shows dedicated open/closed door icons instead of window icons. (#429)
-
-### 🔧 Fixes & Improvements
-
+- **Door contact support (`DOOR_SENSOR` channelRole)** — Added a dedicated `HcuDoorBinarySensor` for channels reporting the `DOOR_SENSOR` channelRole. Previously only `WINDOW_SENSOR` had a mapping, so door contacts configured with this role had no entity created at all. The new binary sensor gets `device_class: door`, is named "Door", and shows dedicated open/closed door icons instead of window icons. (#429)
 - **Missing sensors for ELV-SH-DUSI** — The ultrasonic distance sensor interface reported its values correctly to the HCU, but the integration had no mapping for its channel fields, so they only showed up in the diagnostics export instead of as regular entities. Added `distance` and `calculatedHeight` as sensors, and `referenceHeight` (the configured calibration value) as a diagnostic sensor. (#427)
 
 ## 2.2.1 - 2026-08-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
+## 2.2.3 - Unreleased
+
+### ✨ New Feature: Door contact support (`DOOR_SENSOR` channelRole)
+
+- Added a dedicated `HcuDoorBinarySensor` for channels reporting the `DOOR_SENSOR` channelRole. Previously only `WINDOW_SENSOR` had a mapping, so door contacts configured with this role had no entity created at all. The new binary sensor gets `device_class: door`, is named "Door", and shows dedicated open/closed door icons instead of window icons. (#429)
+
 ## 2.2.2 - 2026-08-26
 
 ### 🔧 Fixes & Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 ### ✨ New Features
 
 - **Door contact support (`DOOR_SENSOR` channelRole)** — Added a dedicated `HcuDoorBinarySensor` for channels reporting the `DOOR_SENSOR` channelRole. Previously only `WINDOW_SENSOR` had a mapping, so door contacts configured with this role had no entity created at all. The new binary sensor gets `device_class: door`, is named "Door", and shows dedicated open/closed door icons instead of window icons. (#429)
-- **Missing sensors for ELV-SH-DUSI** — The ultrasonic distance sensor interface reported its values correctly to the HCU, but the integration had no mapping for its channel fields, so they only showed up in the diagnostics export instead of as regular entities. Added `distance` and `calculatedHeight` as sensors, and `referenceHeight` (the configured calibration value) as a diagnostic sensor. (#427)
+- **New sensors for ELV-SH-DUSI** — Added `distance` and `calculatedHeight` as sensors for the ultrasonic distance sensor interface, plus `referenceHeight` (the configured calibration value) as a diagnostic sensor. Previously these channel fields had no mapping, so they only showed up in the diagnostics export instead of as regular entities. (#427)
 
 ## 2.2.1 - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
-## 2.2.3 - Unreleased
+## 2.2.2 - 2026-08-26
 
 ### ✨ New Feature: Door contact support (`DOOR_SENSOR` channelRole)
 
 - Added a dedicated `HcuDoorBinarySensor` for channels reporting the `DOOR_SENSOR` channelRole. Previously only `WINDOW_SENSOR` had a mapping, so door contacts configured with this role had no entity created at all. The new binary sensor gets `device_class: door`, is named "Door", and shows dedicated open/closed door icons instead of window icons. (#429)
-
-## 2.2.2 - 2026-08-26
 
 ### 🔧 Fixes & Improvements
 

--- a/custom_components/hcu_integration/binary_sensor.py
+++ b/custom_components/hcu_integration/binary_sensor.py
@@ -119,6 +119,22 @@ class HcuWindowBinarySensor(HcuBinarySensor):
         """
         return value in ("OPEN", "TILTED")
 
+
+class HcuDoorBinarySensor(HcuWindowBinarySensor):
+    """
+    Representation of a Homematic IP HCU door contact sensor.
+
+    Behaves exactly like a window sensor (same OPEN/TILTED-based state),
+    but is discovered via the DOOR_SENSOR channelRole (see const.py),
+    which supplies device_class=DOOR and name="Door" through the mapping
+    the base class reads. We only clear the class-level `hcu_window`
+    translation_key here: left in place it would show window icons on a
+    door sensor despite the correct device_class.
+    """
+
+    _attr_translation_key = None
+
+
 class HcuSmokeBinarySensor(HcuBinarySensor):
     """
     Representation of a Homematic IP HCU smoke detector.

--- a/custom_components/hcu_integration/binary_sensor.py
+++ b/custom_components/hcu_integration/binary_sensor.py
@@ -127,12 +127,12 @@ class HcuDoorBinarySensor(HcuWindowBinarySensor):
     Behaves exactly like a window sensor (same OPEN/TILTED-based state),
     but is discovered via the DOOR_SENSOR channelRole (see const.py),
     which supplies device_class=DOOR and name="Door" through the mapping
-    the base class reads. We only clear the class-level `hcu_window`
-    translation_key here: left in place it would show window icons on a
-    door sensor despite the correct device_class.
+    the base class reads. We only override the class-level translation_key
+    to "hcu_door" here: left as "hcu_window" it would show window icons
+    (see icons.json) on a door sensor despite the correct device_class.
     """
 
-    _attr_translation_key = None
+    _attr_translation_key = "hcu_door"
 
 
 class HcuSmokeBinarySensor(HcuBinarySensor):

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -1421,6 +1421,12 @@ HMIP_CHANNEL_ROLE_TO_ENTITY = {
         "class": "HcuDoorbellEvent",
         "name": "Doorbell",
     },
+    "DOOR_SENSOR": {
+        "class": "HcuDoorBinarySensor",
+        "name": "Door",
+        "feature": "windowState",
+        "device_class": BinarySensorDeviceClass.DOOR,
+    },
     "WINDOW_SENSOR": {
         "class": "HcuWindowBinarySensor",
         "name": "Window",

--- a/custom_components/hcu_integration/discovery.py
+++ b/custom_components/hcu_integration/discovery.py
@@ -94,6 +94,7 @@ _CLASS_MODULE_MAP: dict[str, Any] = {
     "HcuWindowStateSensor": sensor,
     "HcuBinarySensor": binary_sensor,
     "HcuWindowBinarySensor": binary_sensor,
+    "HcuDoorBinarySensor": binary_sensor,
     "HcuSmokeBinarySensor": binary_sensor,
     "HcuUnreachBinarySensor": binary_sensor,
     "HcuVacationModeBinarySensor": binary_sensor,

--- a/custom_components/hcu_integration/icons.json
+++ b/custom_components/hcu_integration/icons.json
@@ -36,6 +36,13 @@
                     "on": "mdi:window-open-variant",
                     "off": "mdi:window-closed-variant"
                 }
+            },
+            "hcu_door": {
+                "default": "mdi:door-closed",
+                "state": {
+                    "on": "mdi:door-open",
+                    "off": "mdi:door-closed"
+                }
             }
         },
         "sensor":{

--- a/tests/mock_hass/homeassistant/components/binary_sensor/__init__.py
+++ b/tests/mock_hass/homeassistant/components/binary_sensor/__init__.py
@@ -1,6 +1,7 @@
 class BinarySensorDeviceClass:
     BATTERY = "battery"
     CONNECTIVITY = "connectivity"
+    DOOR = "door"
     WINDOW = "window"
     MOTION = "motion"
     OCCUPANCY = "occupancy"


### PR DESCRIPTION
## Description

`HMIP_CHANNEL_ROLE_TO_ENTITY` already mapped the `WINDOW_SENSOR` channel role to `HcuWindowBinarySensor`, but there was no equivalent for `DOOR_SENSOR` — channels reporting that role had no dedicated entity mapping.

This adds a minimal `HcuDoorBinarySensor(HcuWindowBinarySensor)` subclass, registered for the `DOOR_SENSOR` role:

- Inherits the existing OPEN/TILTED state logic unchanged from `HcuWindowBinarySensor`.
- `device_class="door"` and `name="Door"` come from the new `const.py` mapping entry through the existing base-class handling (`HcuBinarySensor.__init__` already reads `device_class`/`name` from the mapping dict) — no per-instance branching needed, same pattern `WINDOW_SENSOR` already uses.
- Only overrides the class-level `translation_key` to `"hcu_door"` (instead of inheriting `"hcu_window"`), with a matching `icons.json` entry (`mdi:door-open` / `mdi:door-closed`) so a door contact gets door icons instead of window icons.

## Motivation & Context

Devices exposing a `DOOR_SENSOR` channelRole (e.g. contact channels explicitly configured as a door contact rather than a window contact) currently fall through without any entity mapping for that role, so no binary_sensor entity is created for them. This closes that gap.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## How Was It Tested?
- [ ] Unit tests
- [x] Manually tested

The repo's local `tests/mock_hass` harness currently doesn't import cleanly on a plain `main` checkout independent of this change (several `homeassistant` mock stubs — `helpers.issue_registry`, `helpers.config_validation`, a number of `Platform`/device-class members — are missing relative to what the app's current source actually needs), so `uv run pytest` doesn't run end-to-end on `main` today. That gap predates this PR and is out of scope here, so it wasn't touched.

Instead, the new code path was verified with a standalone script that fakes the missing pieces in-memory (not part of this diff) and exercises the real code:
- `HMIP_CHANNEL_ROLE_TO_ENTITY["DOOR_SENSOR"]` mapping wired correctly (class/name/feature/device_class).
- `HcuDoorBinarySensor` correctly subclasses `HcuWindowBinarySensor`; `translation_key` is `"hcu_door"` while `HcuWindowBinarySensor` keeps `"hcu_window"`.
- Instantiated both classes through their real constructors with fake coordinator/client/device data: `HcuDoorBinarySensor` reports `device_class=door`, `is_on=True` for an `OPEN` `windowState` value, and `translation_key="hcu_door"`; `HcuWindowBinarySensor` is unaffected (`device_class=window`, `is_on=False` for `CLOSED`, `translation_key="hcu_window"`).
- Confirmed `mdi:door-open` / `mdi:door-closed` are valid Material Design Icons.
- Confirmed via `grep` that no other file in the integration (config_flow, repairs, diagnostics, ha_entity_bridge, climate, sensor) references `HcuWindowBinarySensor`/`WINDOW_SENSOR`/`windowState` in a way that would need updating for the new class.

## Checklist
- [x] Code follows the project style
- [ ] Tests added
- [x] Documentation updated

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZ4untjBrnEGyJ81dJy4Qg)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds dedicated Home Assistant binary-sensor support for HCU channels using the `DOOR_SENSOR` role.
- Maps `DOOR_SENSOR` channels to a new `HcuDoorBinarySensor` using the existing `windowState` behavior.
- Registers the class with discovery and supplies door-specific metadata and icons.
- Extends the test Home Assistant stub with the door device class and updates the changelog.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with the new role mapping, class registration, metadata, and icon resources aligned.

The added discovery path resolves to an existing binary-sensor platform, passes the expected mapping metadata into the inherited implementation, and introduces no established contract or runtime failure.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/hcu_integration/const.py | Adds an internally consistent `DOOR_SENSOR` mapping to the binary-sensor class, feature, name, and device class. |
| custom_components/hcu_integration/binary_sensor.py | Adds a minimal door subclass that safely reuses the existing open/tilted state conversion and overrides icon translation metadata. |
| custom_components/hcu_integration/discovery.py | Registers the new string-addressed entity class with the binary-sensor module used by discovery. |
| custom_components/hcu_integration/icons.json | Adds matching on/off door icons for the new translation key. |
| tests/mock_hass/homeassistant/components/binary_sensor/__init__.py | Extends the Home Assistant test stub with the device-class constant required by the new mapping. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    HCU[HCU DOOR_SENSOR channel] --> MAP[Role mapping]
    MAP --> DISC[Discovery resolves HcuDoorBinarySensor]
    DISC --> STATE[Read windowState]
    STATE --> ENTITY[Home Assistant door binary sensor]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: reword ELV-SH-DUSI entry to lead w..."](https://github.com/ediminator/homematicip-hcu/commit/38cb4c62ae89f6040fc1340ac8d66f9a889b1672) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56964556)</sub>

<!-- /greptile_comment -->