### PR TITLE
Fix: register services once in async_setup to avoid service_not_found race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
+## Unreleased
+
+### 🐛 Bug: `service_not_found` repair issues on every start/reload
+
+Integration services (e.g. `hcu_integration.send_api_command`) were registered **after** entities were forwarded to their platforms in `async_setup_entry`, and unregistered **before** platforms were unloaded in `async_unload_entry`. This opened a race window on every Home Assistant start and every integration reload during which HCU entities were already available (and firing state changes) while the services did not exist yet — or anymore. Automations reacting to HCU entity state changes and calling an HCU service could reliably hit `service_not_found` repair issues, one per affected automation, on every restart. (#431)
+
+Services are now registered once in `async_setup` (before any config entry is set up) and never unregistered, so they exist for the entire lifetime of Home Assistant regardless of config entry setup/reload/unload timing.
+
 ## 2.2.3 - 2026-08-27
 
 ### 🐛 Bug: HA Entity Bridge devices never appeared in the Homematic IP app inbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
-## Unreleased
+## 2.2.4 - 2026-08-31
 
 ### 🐛 Bug: `service_not_found` repair issues on every start/reload
 
 Integration services (e.g. `hcu_integration.send_api_command`) were registered **after** entities were forwarded to their platforms in `async_setup_entry`, and unregistered **before** platforms were unloaded in `async_unload_entry`. This opened a race window on every Home Assistant start and every integration reload during which HCU entities were already available (and firing state changes) while the services did not exist yet — or anymore. Automations reacting to HCU entity state changes and calling an HCU service could reliably hit `service_not_found` repair issues, one per affected automation, on every restart. (#431)
 
-Services are now registered once in `async_setup` (before any config entry is set up) and never unregistered, so they exist for the entire lifetime of Home Assistant regardless of config entry setup/reload/unload timing.
+- Services are now registered once in `async_setup` (before any config entry is set up) and never unregistered, so they exist for the entire lifetime of Home Assistant regardless of config entry setup/reload/unload timing.
+- Since services can now be called while no HCU config entry is loaded (e.g. the brief window during a config entry reload), the service handlers that talk to the HCU client directly (`send_api_command`, `user_message`, `user_message_delete`) now handle that case explicitly instead of raising an unhandled error.
 
 ## 2.2.3 - 2026-08-27
 

--- a/custom_components/hcu_integration/__init__.py
+++ b/custom_components/hcu_integration/__init__.py
@@ -69,11 +69,7 @@ from .const import (
 from .ha_entity_bridge import HaEntityBridge
 
 from .discovery import async_discover_entities
-from .services import (
-    INTEGRATION_SERVICES,
-    async_register_services,
-    async_unregister_services,
-)
+from .services import async_register_services
 from . import event
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,10 +78,18 @@ type HcuData = dict[str, "HcuCoordinator"]
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-SERVICE_ENTRIES_KEY = f"{DOMAIN}_service_entries"
-
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    """Set up the HCU component."""
+    """Set up the HCU component.
+
+    Services are entry-independent: they are registered once here, before
+    any config entry is set up, and never unregistered. This avoids a race
+    where entities from a config entry become available (and start firing
+    state changes that automations react to) before the services they call
+    exist — or stop existing while entities are still around during a
+    reload. `_get_client_for_service()` raises a clear error if a service
+    is called without a loaded config entry.
+    """
+    async_register_services(hass)
     return True
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -176,12 +180,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Register services (only once for first config entry)
-    service_entries: set[str] = hass.data.setdefault(SERVICE_ENTRIES_KEY, set())
-    if not service_entries:
-        async_register_services(hass)
-    service_entries.add(entry.entry_id)
-
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     if entry.data.get(CONF_AUTH_TYPE, AUTH_TYPE_PLUGIN) == AUTH_TYPE_PLUGIN:
@@ -196,14 +194,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     coordinator: HcuCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    if SERVICE_ENTRIES_KEY in hass.data:
-        service_entries: set[str] = hass.data[SERVICE_ENTRIES_KEY]
-        service_entries.discard(entry.entry_id)
-
-        if not service_entries:
-            async_unregister_services(hass)
-            hass.data.pop(SERVICE_ENTRIES_KEY, None)
 
     if hasattr(coordinator, "_ha_bridge") and coordinator._ha_bridge:
         coordinator._ha_bridge.stop_listening()

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -54,7 +54,7 @@ PLUGIN_FRIENDLY_NAME = {
     "de": "Home Assistant Integration",
     "en": "Home Assistant Integration",
 }
-PLUGIN_VERSION = "2.2.3"
+PLUGIN_VERSION = "2.2.4"
 PLUGIN_DOCUMENTATION_URL = "https://github.com/Ediminator/homematicip-hcu"
 PLUGIN_ISSUE_TRACKER_URL = "https://github.com/Ediminator/homematicip-hcu/issues"
 

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -15,6 +15,6 @@
     "aiohttp>=3.0.0",
     "getmac>=0.8.0"
   ],
-  "version": "2.2.3",
+  "version": "2.2.4",
   "zeroconf": [{"type": "_ssh._tcp.local.", "name": "hcu1*"}]
 }

--- a/custom_components/hcu_integration/services.py
+++ b/custom_components/hcu_integration/services.py
@@ -261,7 +261,8 @@ async def async_handle_send_api_command(hass: HomeAssistant, call: ServiceCall) 
         
     except (HcuApiError, ConnectionError) as err:
         _LOGGER.error("Error calling send_api_command for path %s: %s", path, err)
-    
+    except ValueError as err:
+        _LOGGER.error("No HCU available: %s", err)
 
 
 async def async_handle_set_cooling_mode(hass: HomeAssistant, call: ServiceCall) -> None:
@@ -343,7 +344,9 @@ async def async_create_user_message_request(
         await client.async_create_user_message_request(body=body)
     except (HcuApiError, ConnectionError) as err:
         _LOGGER.error("Error calling create_user_message_request: %s", err)
-    
+    except ValueError as err:
+        _LOGGER.error("No HCU available: %s", err)
+
 async def async_delete_user_message_request(hass: HomeAssistant, call: ServiceCall) -> None:
     user_message_id = call.data.get(ATTR_USER_MESSAGE_ID)
 
@@ -361,6 +364,8 @@ async def async_delete_user_message_request(hass: HomeAssistant, call: ServiceCa
         )
     except (HcuApiError, ConnectionError) as err:
         raise ServiceValidationError(f"Failed to delete user message {user_message_id}: {err}") from err
+    except ValueError as err:
+        raise ServiceValidationError(f"No HCU available: {err}") from err
         
 def async_register_services(hass: HomeAssistant) -> None:
     """Register all HCU integration services."""

--- a/custom_components/hcu_integration/services.py
+++ b/custom_components/hcu_integration/services.py
@@ -389,10 +389,3 @@ def async_register_services(hass: HomeAssistant) -> None:
         )
 
     _LOGGER.debug("Registered %d HCU services", len(service_handlers))
-    
-def async_unregister_services(hass: HomeAssistant) -> None:
-    """Unregister all HCU integration services."""
-    for service_name in INTEGRATION_SERVICES:
-        hass.services.async_remove(DOMAIN, service_name)
-
-    _LOGGER.debug("Unregistered HCU services")


### PR DESCRIPTION
## Description
Registers HCU integration services (`hcu_integration.send_api_command`, `play_sound`, etc.) once in `async_setup`, before any config entry is set up, instead of registering them after `async_forward_entry_setups()` and unregistering them before `async_unload_platforms()` on every entry setup/reload/unload. Also brings the three service handlers that talk to the HCU client directly (`send_api_command`, `user_message`, `user_message_delete`) in line with the other handlers by catching the `ValueError` `_get_client_for_service()` raises when no client is available. Bumps the integration version to 2.2.4.

## Motivation & Context
Services were previously registered **after** entities were forwarded to their platforms, and unregistered **before** platforms were unloaded. This opened a race window on every Home Assistant start and every integration reload during which HCU entities were already available (and firing state changes) while the services they depend on did not exist yet — or anymore. Automations reacting to HCU entity state changes and calling an HCU service could reliably hit `service_not_found` repair issues, one per affected automation, on every restart — worse the more entities/devices an installation has, since platform forwarding takes longer and widens the race window.

Per the fix proposed in the issue (Option B, the idiomatic pattern for entry-independent services per the HA developer docs): register services once in `async_setup` and never unregister them on unload. `_get_client_for_service()` already raised a clear error when no client was available for most handlers; this PR extends that handling to the three handlers that were missing it, since a service call while no config entry is loaded (e.g. the brief window during a reload) is now a reachable case rather than a purely theoretical one.

Fixes #431

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## How Was It Tested?
- [ ] Unit tests
- [x] Manually tested — reasoned through the fix against Home Assistant's component/config-entry lifecycle (`async_setup` is called once before any config entry, and is not re-invoked on entry reload), verified no other code references the removed `SERVICE_ENTRIES_KEY`/`async_unregister_services`, and confirmed all 8 service handlers that call `_get_client_for_service()` now handle the "no client available" case consistently. Could not run the existing pytest suite in this environment (no `pytest`/`homeassistant` package available), but none of the existing tests exercise this registration path.

## Checklist
- [x] Code follows the project style
- [ ] Tests added
- [x] Documentation updated (CHANGELOG.md, version bump)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JAbVqQmwCDNhqzincZdUSw)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR moves HCU service registration to component setup so the service surface remains available throughout config-entry setup, reload, and unload. It also handles service calls made without an available HCU client and updates the integration version and changelog.

- Registers integration services once from `async_setup`.
- Removes per-entry service ownership tracking and unregistration.
- Handles unavailable-client errors in the three remaining direct-client service handlers.
- Bumps the integration version to 2.2.4.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defect identified.

Process-wide registration removes the service availability gap while the handlers cover the newly reachable no-client state; the investigated unload and multi-entry behaviors did not reveal a new actionable failure introduced by this change.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/hcu_integration/__init__.py | Moves process-wide service registration into component setup and removes per-entry registration ownership and teardown. |
| custom_components/hcu_integration/services.py | Adds unavailable-client handling to the remaining direct-client handlers and removes the obsolete service-unregistration helper. |
| custom_components/hcu_integration/const.py | Updates the HCU plugin version to 2.2.4. |
| custom_components/hcu_integration/manifest.json | Updates the published integration version to 2.2.4. |
| CHANGELOG.md | Documents the service lifecycle race fix and unavailable-client handling. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant HA as Home Assistant
    participant Integration as HCU Integration
    participant Services as Service Registry
    participant Entry as Config Entry
    participant Client as HCU Client

    HA->>Integration: async_setup()
    Integration->>Services: Register HCU services once
    HA->>Entry: async_setup_entry()
    Entry->>Client: Connect and initialize
    Entry->>HA: Forward entity platforms
    Note over Services,Entry: Services remain registered during reload
    HA->>Entry: async_unload_entry()
    Entry->>HA: Unload entity platforms
    Entry->>Client: Disconnect
    HA->>Entry: async_setup_entry()
    Entry->>Client: Reconnect and initialize
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Release 2.2.4"](https://github.com/ediminator/homematicip-hcu/commit/3c07bd6abf3b0496953a76a803faf1207dd0e5c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58534942)</sub>

**Context used:**

- Knowledge Base — [Home Assistant integration lifecycle](https://app.greptile.com/ediminator/-/custom-context/knowledge-base/ediminator/homematicip-hcu/-/docs/integration-lifecycle.md)
- Knowledge Base — [Automation interfaces](https://app.greptile.com/ediminator/-/custom-context/knowledge-base/ediminator/homematicip-hcu/-/docs/automation-interfaces.md)

<!-- /greptile_comment -->