### PR TITLE
Fix: cover briefly shows wrong opening/closing direction (#433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 
 ### 🐛 Bug: cover briefly showed the wrong opening/closing direction
 
-Right after a shutter/blind started moving, `is_opening`/`is_closing` could briefly show the opposite direction before correcting itself a moment later, showing up as a wrong entry in the logbook/history. (#433)
+Right after a shutter/blind started moving, the HCU itself briefly reports the wrong `lastShadingDirection` (the previous move's direction) before correcting it a moment later — so `is_opening`/`is_closing` showed the opposite direction for a moment, showing up as a wrong entry in the logbook/history. This is incorrect data coming from the HCU, not something the integration can fix at the source, so the following is a workaround rather than a real fix. (#433)
 
-- Commands sent from Home Assistant now set the direction locally the instant they're issued, instead of waiting on the HCU's own (sometimes briefly stale) report.
-- For moves triggered elsewhere (native app, wall switch), the direction is now held back for ~2s after the move starts rather than risk showing the wrong one.
+- Commands sent from Home Assistant now set the direction locally the instant they're issued, instead of waiting on the HCU's (briefly wrong) report.
+- For moves triggered elsewhere (native app, wall switch), where we have no direction of our own to fall back on, the direction is now held back for ~2s after the move starts rather than risk showing the HCU's incorrect value.
 
 ## 2.2.4 - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the Homematic IP Local (HCU) integration will be document
 Right after a shutter/blind started moving, the HCU itself briefly reports the wrong `lastShadingDirection` (the previous move's direction) before correcting it a moment later — so `is_opening`/`is_closing` showed the opposite direction for a moment, showing up as a wrong entry in the logbook/history. This is incorrect data coming from the HCU, not something the integration can fix at the source, so the following is a workaround rather than a real fix. (#433)
 
 - Commands sent from Home Assistant now set the direction locally the instant they're issued, instead of waiting on the HCU's (briefly wrong) report.
-- For moves triggered elsewhere (native app, wall switch), where we have no direction of our own to fall back on, the direction is now held back for ~2s after the move starts rather than risk showing the HCU's incorrect value.
+- For moves triggered elsewhere (native app, wall switch), where we have no direction of our own to fall back on, the direction is now held back for ~3s after the move starts rather than risk showing the HCU's incorrect value.
 
 ## 2.2.4 - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the Homematic IP Local (HCU) integration will be documented in this file.
 
+## 2.2.5 - 2026-09-01
+
+### 🐛 Bug: cover briefly showed the wrong opening/closing direction
+
+Right after a shutter/blind started moving, `is_opening`/`is_closing` could briefly show the opposite direction before correcting itself a moment later, showing up as a wrong entry in the logbook/history. (#433)
+
+- Commands sent from Home Assistant now set the direction locally the instant they're issued, instead of waiting on the HCU's own (sometimes briefly stale) report.
+- For moves triggered elsewhere (native app, wall switch), the direction is now held back for ~2s after the move starts rather than risk showing the wrong one.
+
 ## 2.2.4 - 2026-08-31
 
 ### 🐛 Bug: `service_not_found` repair issues on every start/reload

--- a/custom_components/hcu_integration/const.py
+++ b/custom_components/hcu_integration/const.py
@@ -54,7 +54,7 @@ PLUGIN_FRIENDLY_NAME = {
     "de": "Home Assistant Integration",
     "en": "Home Assistant Integration",
 }
-PLUGIN_VERSION = "2.2.4"
+PLUGIN_VERSION = "2.2.5"
 PLUGIN_DOCUMENTATION_URL = "https://github.com/Ediminator/homematicip-hcu"
 PLUGIN_ISSUE_TRACKER_URL = "https://github.com/Ediminator/homematicip-hcu/issues"
 

--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -71,6 +71,14 @@ class HcuCover(HcuBaseEntity, CoverEntity):
 
         self._attr_unique_id = f"{self._device_id}_{self._channel_index}_cover"
 
+        # Optimistic movement direction, set locally when HA issues a move command.
+        # The HCU briefly reports the *previous* movement's lastShadingDirection
+        # after processing flips to True, before pushing the corrected value a
+        # moment later. Overriding with the direction we just commanded avoids
+        # that flicker; it is cleared once the coordinator confirms the move
+        # has actually finished (see _handle_coordinator_update below).
+        self._optimistic_direction: str | None = None
+
         device_type = self._device.get("type")
         self._attr_device_class = HMIP_DEVICE_TYPE_TO_DEVICE_CLASS.get(device_type)
 
@@ -126,11 +134,19 @@ class HcuCover(HcuBaseEntity, CoverEntity):
 
     @property
     def is_opening(self) -> bool:
-        return (self._channel.get("lastShadingDirection") == "LIGHTER" and self._channel.get("processing") == True)
+        if self._channel.get("processing") != True:
+            return False
+        if self._optimistic_direction is not None:
+            return self._optimistic_direction == "opening"
+        return self._channel.get("lastShadingDirection") == "LIGHTER"
 
     @property
     def is_closing(self) -> bool:
-        return (self._channel.get("lastShadingDirection") == "DARKER" and self._channel.get("processing") == True)
+        if self._channel.get("processing") != True:
+            return False
+        if self._optimistic_direction is not None:
+            return self._optimistic_direction == "closing"
+        return self._channel.get("lastShadingDirection") == "DARKER"
 
     @property
     def is_closed(self) -> bool | None:
@@ -140,25 +156,43 @@ class HcuCover(HcuBaseEntity, CoverEntity):
             return None
         return pos == 0
 
+    def _handle_coordinator_update(self) -> None:
+        """Clear the optimistic direction once the coordinator confirms the move ended."""
+        if self._device_id in self.coordinator.data and self._channel.get("processing") != True:
+            self._optimistic_direction = None
+        super()._handle_coordinator_update()
+
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         self._attr_assumed_state = True
+        self._optimistic_direction = "opening"
         await self._async_set_level(self._device_id, self._channel_index, 0.0)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         self._attr_assumed_state = True
+        self._optimistic_direction = "closing"
         await self._async_set_level(self._device_id, self._channel_index, 1.0)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         self._attr_assumed_state = True
+        self._optimistic_direction = None
         await self._client.async_stop_cover(self._device_id, self._channel_index)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position = kwargs.get(ATTR_POSITION, 100)
         self._attr_assumed_state = True
+        current_position = self.current_cover_position
+        if current_position is None:
+            self._optimistic_direction = None
+        elif position > current_position:
+            self._optimistic_direction = "opening"
+        elif position < current_position:
+            self._optimistic_direction = "closing"
+        else:
+            self._optimistic_direction = None
         shutter_level = round((100 - position) / 100.0, 2)
         await self._async_set_level(self._device_id, self._channel_index, shutter_level)
         

--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -38,7 +38,7 @@ TILT_FEATURES = (
 # letting a real external override (wall switch, native app) during an
 # ongoing HA-commanded move win back the display within a few seconds instead
 # of being stuck for the rest of that move.
-OPTIMISTIC_DIRECTION_GRACE_SECONDS = 5.0
+OPTIMISTIC_DIRECTION_GRACE_SECONDS = 2.0
 
 def _level_to_position(level: float | None) -> int | None:
     """Convert HCU level (0.0-1.0, 1.0 is closed) to Home Assistant position (0-100, 0 is closed)."""

--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -92,6 +92,18 @@ class HcuCover(HcuBaseEntity, CoverEntity):
         self._optimistic_direction: str | None = None
         self._optimistic_direction_set_at: float | None = None
 
+        # Direction derived from the change in current_cover_position between
+        # coordinator updates. Unlike lastShadingDirection (an HCU-computed
+        # field that can lag or report stale data for several seconds
+        # regardless of who triggered the move - HA, the native app, or a
+        # wall switch), the position itself is a direct physical readout of
+        # the motor and updates reliably. This is the primary source for
+        # is_opening/is_closing whenever a position change has actually been
+        # observed; lastShadingDirection is only used as a last-resort
+        # fallback before any position delta is available.
+        self._observed_direction: str | None = None
+        self._last_known_position: int | None = None
+
         device_type = self._device.get("type")
         self._attr_device_class = HMIP_DEVICE_TYPE_TO_DEVICE_CLASS.get(device_type)
 
@@ -103,6 +115,10 @@ class HcuCover(HcuBaseEntity, CoverEntity):
         else:
             self._async_set_level = self._client.async_set_shutter_level
             self._level_property = "shutterLevel"
+
+        # Baseline for the position-delta direction tracking above; needs the
+        # level property to be known first.
+        self._last_known_position = self.current_cover_position
 
         self._attr_supported_features = (
             CoverEntityFeature.OPEN
@@ -171,6 +187,8 @@ class HcuCover(HcuBaseEntity, CoverEntity):
             return False
         if (direction := self._active_optimistic_direction) is not None:
             return direction == "opening"
+        if self._observed_direction is not None:
+            return self._observed_direction == "opening"
         return self._channel.get("lastShadingDirection") == "LIGHTER"
 
     @property
@@ -179,6 +197,8 @@ class HcuCover(HcuBaseEntity, CoverEntity):
             return False
         if (direction := self._active_optimistic_direction) is not None:
             return direction == "closing"
+        if self._observed_direction is not None:
+            return self._observed_direction == "closing"
         return self._channel.get("lastShadingDirection") == "DARKER"
 
     @property
@@ -190,9 +210,31 @@ class HcuCover(HcuBaseEntity, CoverEntity):
         return pos == 0
 
     def _handle_coordinator_update(self) -> None:
-        """Clear the optimistic direction once the coordinator confirms the move ended."""
-        if self._device_id in self.coordinator.data and self._channel.get("processing") != True:
-            self._set_optimistic_direction(None)
+        """Track the observed direction from position changes and clear stale overrides.
+
+        Runs on every push from the coordinator, regardless of who triggered the
+        move (HA, the native app, or a wall switch), so is_opening/is_closing can
+        rely on the actual reported position instead of the HCU's own
+        lastShadingDirection field.
+        """
+        if self._device_id in self.coordinator.data:
+            processing = self._channel.get("processing") == True
+            new_position = self.current_cover_position
+            if (
+                processing
+                and new_position is not None
+                and self._last_known_position is not None
+            ):
+                if new_position > self._last_known_position:
+                    self._observed_direction = "opening"
+                elif new_position < self._last_known_position:
+                    self._observed_direction = "closing"
+                # unchanged position: no new information yet, keep the last one
+            if not processing:
+                self._observed_direction = None
+                self._set_optimistic_direction(None)
+            if new_position is not None:
+                self._last_known_position = new_position
         super()._handle_coordinator_update()
 
     async def async_open_cover(self, **kwargs: Any) -> None:

--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -38,7 +38,7 @@ TILT_FEATURES = (
 # letting a real external override (wall switch, native app) during an
 # ongoing HA-commanded move win back the display within a few seconds instead
 # of being stuck for the rest of that move.
-OPTIMISTIC_DIRECTION_GRACE_SECONDS = 2.0
+OPTIMISTIC_DIRECTION_GRACE_SECONDS = 3.0
 
 def _level_to_position(level: float | None) -> int | None:
     """Convert HCU level (0.0-1.0, 1.0 is closed) to Home Assistant position (0-100, 0 is closed)."""

--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -48,7 +48,7 @@ OPTIMISTIC_DIRECTION_GRACE_SECONDS = 3.0
 # native-app follow-up. Since there is no local optimistic direction for
 # externally triggered moves, we simply don't show a direction until it has
 # had time to settle, rather than risk showing the wrong one.
-DIRECTION_SETTLE_SECONDS = 2.0
+DIRECTION_SETTLE_SECONDS = 3.0
 
 def _level_to_position(level: float | None) -> int | None:
     """Convert HCU level (0.0-1.0, 1.0 is closed) to Home Assistant position (0-100, 0 is closed)."""

--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -2,6 +2,7 @@
 """Cover platform for the Homematic IP HCU integration."""
 from typing import TYPE_CHECKING, Any
 import logging
+import time
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
@@ -30,6 +31,14 @@ TILT_FEATURES = (
     | CoverEntityFeature.CLOSE_TILT
     | CoverEntityFeature.STOP_TILT
 )
+
+# How long a locally commanded (optimistic) movement direction is trusted over
+# the HCU-reported lastShadingDirection. Covers the ~1-2s the HCU needs to
+# correct a stale direction after a command (see issue #433), while still
+# letting a real external override (wall switch, native app) during an
+# ongoing HA-commanded move win back the display within a few seconds instead
+# of being stuck for the rest of that move.
+OPTIMISTIC_DIRECTION_GRACE_SECONDS = 5.0
 
 def _level_to_position(level: float | None) -> int | None:
     """Convert HCU level (0.0-1.0, 1.0 is closed) to Home Assistant position (0-100, 0 is closed)."""
@@ -75,9 +84,13 @@ class HcuCover(HcuBaseEntity, CoverEntity):
         # The HCU briefly reports the *previous* movement's lastShadingDirection
         # after processing flips to True, before pushing the corrected value a
         # moment later. Overriding with the direction we just commanded avoids
-        # that flicker; it is cleared once the coordinator confirms the move
-        # has actually finished (see _handle_coordinator_update below).
+        # that flicker. It is cleared once the coordinator confirms the move has
+        # actually finished (see _handle_coordinator_update below), and it also
+        # expires on its own after OPTIMISTIC_DIRECTION_GRACE_SECONDS so that a
+        # real external override (wall switch, native app) taking over an
+        # ongoing HA-commanded move isn't masked for the rest of that move.
         self._optimistic_direction: str | None = None
+        self._optimistic_direction_set_at: float | None = None
 
         device_type = self._device.get("type")
         self._attr_device_class = HMIP_DEVICE_TYPE_TO_DEVICE_CLASS.get(device_type)
@@ -132,20 +145,40 @@ class HcuCover(HcuBaseEntity, CoverEntity):
         """Return current tilt position of cover."""
         return _level_to_position(self._channel.get("slatsLevel"))
 
+    def _set_optimistic_direction(self, direction: str | None) -> None:
+        """Set (or clear) the locally commanded direction override, timestamped for expiry."""
+        self._optimistic_direction = direction
+        self._optimistic_direction_set_at = time.monotonic() if direction is not None else None
+
+    @property
+    def _active_optimistic_direction(self) -> str | None:
+        """Return the optimistic direction if it hasn't expired yet, else None.
+
+        The expiry ensures that a real external override (wall switch, native
+        app) taking over an already-running HA-commanded move eventually wins
+        back the displayed direction, instead of being masked indefinitely
+        until the HCU reports processing=False.
+        """
+        if self._optimistic_direction is None or self._optimistic_direction_set_at is None:
+            return None
+        if time.monotonic() - self._optimistic_direction_set_at > OPTIMISTIC_DIRECTION_GRACE_SECONDS:
+            return None
+        return self._optimistic_direction
+
     @property
     def is_opening(self) -> bool:
         if self._channel.get("processing") != True:
             return False
-        if self._optimistic_direction is not None:
-            return self._optimistic_direction == "opening"
+        if (direction := self._active_optimistic_direction) is not None:
+            return direction == "opening"
         return self._channel.get("lastShadingDirection") == "LIGHTER"
 
     @property
     def is_closing(self) -> bool:
         if self._channel.get("processing") != True:
             return False
-        if self._optimistic_direction is not None:
-            return self._optimistic_direction == "closing"
+        if (direction := self._active_optimistic_direction) is not None:
+            return direction == "closing"
         return self._channel.get("lastShadingDirection") == "DARKER"
 
     @property
@@ -159,25 +192,25 @@ class HcuCover(HcuBaseEntity, CoverEntity):
     def _handle_coordinator_update(self) -> None:
         """Clear the optimistic direction once the coordinator confirms the move ended."""
         if self._device_id in self.coordinator.data and self._channel.get("processing") != True:
-            self._optimistic_direction = None
+            self._set_optimistic_direction(None)
         super()._handle_coordinator_update()
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         self._attr_assumed_state = True
-        self._optimistic_direction = "opening"
+        self._set_optimistic_direction("opening")
         await self._async_set_level(self._device_id, self._channel_index, 0.0)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
         self._attr_assumed_state = True
-        self._optimistic_direction = "closing"
+        self._set_optimistic_direction("closing")
         await self._async_set_level(self._device_id, self._channel_index, 1.0)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         self._attr_assumed_state = True
-        self._optimistic_direction = None
+        self._set_optimistic_direction(None)
         await self._client.async_stop_cover(self._device_id, self._channel_index)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
@@ -186,13 +219,13 @@ class HcuCover(HcuBaseEntity, CoverEntity):
         self._attr_assumed_state = True
         current_position = self.current_cover_position
         if current_position is None:
-            self._optimistic_direction = None
+            self._set_optimistic_direction(None)
         elif position > current_position:
-            self._optimistic_direction = "opening"
+            self._set_optimistic_direction("opening")
         elif position < current_position:
-            self._optimistic_direction = "closing"
+            self._set_optimistic_direction("closing")
         else:
-            self._optimistic_direction = None
+            self._set_optimistic_direction(None)
         shutter_level = round((100 - position) / 100.0, 2)
         await self._async_set_level(self._device_id, self._channel_index, shutter_level)
         

--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -12,8 +12,9 @@ from homeassistant.components.cover import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 
 from .const import HMIP_DEVICE_TYPE_TO_DEVICE_CLASS, API_PATHS
 from .entity import HcuBaseEntity, HcuGroupBaseEntity
@@ -39,6 +40,15 @@ TILT_FEATURES = (
 # ongoing HA-commanded move win back the display within a few seconds instead
 # of being stuck for the rest of that move.
 OPTIMISTIC_DIRECTION_GRACE_SECONDS = 3.0
+
+# How long to wait after processing first flips to True before trusting the
+# raw lastShadingDirection field at all. The HCU's own direction data can be
+# stale/wrong for the first moment or two of a move regardless of who
+# triggered it (HA, native app, wall switch) - see issue #433 and its
+# native-app follow-up. Since there is no local optimistic direction for
+# externally triggered moves, we simply don't show a direction until it has
+# had time to settle, rather than risk showing the wrong one.
+DIRECTION_SETTLE_SECONDS = 2.0
 
 def _level_to_position(level: float | None) -> int | None:
     """Convert HCU level (0.0-1.0, 1.0 is closed) to Home Assistant position (0-100, 0 is closed)."""
@@ -92,17 +102,12 @@ class HcuCover(HcuBaseEntity, CoverEntity):
         self._optimistic_direction: str | None = None
         self._optimistic_direction_set_at: float | None = None
 
-        # Direction derived from the change in current_cover_position between
-        # coordinator updates. Unlike lastShadingDirection (an HCU-computed
-        # field that can lag or report stale data for several seconds
-        # regardless of who triggered the move - HA, the native app, or a
-        # wall switch), the position itself is a direct physical readout of
-        # the motor and updates reliably. This is the primary source for
-        # is_opening/is_closing whenever a position change has actually been
-        # observed; lastShadingDirection is only used as a last-resort
-        # fallback before any position delta is available.
-        self._observed_direction: str | None = None
-        self._last_known_position: int | None = None
+        # Wall-clock time (monotonic) this move started, i.e. when we first
+        # saw processing=True. Used to hold back the raw lastShadingDirection
+        # field for DIRECTION_SETTLE_SECONDS (see constant above) for moves
+        # that have no local optimistic direction to rely on instead.
+        self._processing_started_at: float | None = None
+        self._settle_unsub: Any = None
 
         device_type = self._device.get("type")
         self._attr_device_class = HMIP_DEVICE_TYPE_TO_DEVICE_CLASS.get(device_type)
@@ -115,10 +120,6 @@ class HcuCover(HcuBaseEntity, CoverEntity):
         else:
             self._async_set_level = self._client.async_set_shutter_level
             self._level_property = "shutterLevel"
-
-        # Baseline for the position-delta direction tracking above; needs the
-        # level property to be known first.
-        self._last_known_position = self.current_cover_position
 
         self._attr_supported_features = (
             CoverEntityFeature.OPEN
@@ -182,13 +183,23 @@ class HcuCover(HcuBaseEntity, CoverEntity):
         return self._optimistic_direction
 
     @property
+    def _raw_direction_settled(self) -> bool:
+        """Whether enough time has passed since this move started for a
+        stale/wrong lastShadingDirection to have self-corrected. Only
+        consulted when there is no local optimistic direction, i.e. for
+        moves HA didn't itself command (native app, wall switch)."""
+        if self._processing_started_at is None:
+            return True
+        return time.monotonic() - self._processing_started_at >= DIRECTION_SETTLE_SECONDS
+
+    @property
     def is_opening(self) -> bool:
         if self._channel.get("processing") != True:
             return False
         if (direction := self._active_optimistic_direction) is not None:
             return direction == "opening"
-        if self._observed_direction is not None:
-            return self._observed_direction == "opening"
+        if not self._raw_direction_settled:
+            return False
         return self._channel.get("lastShadingDirection") == "LIGHTER"
 
     @property
@@ -197,8 +208,8 @@ class HcuCover(HcuBaseEntity, CoverEntity):
             return False
         if (direction := self._active_optimistic_direction) is not None:
             return direction == "closing"
-        if self._observed_direction is not None:
-            return self._observed_direction == "closing"
+        if not self._raw_direction_settled:
+            return False
         return self._channel.get("lastShadingDirection") == "DARKER"
 
     @property
@@ -209,32 +220,50 @@ class HcuCover(HcuBaseEntity, CoverEntity):
             return None
         return pos == 0
 
-    def _handle_coordinator_update(self) -> None:
-        """Track the observed direction from position changes and clear stale overrides.
+    def _cancel_direction_settle_check(self) -> None:
+        """Cancel a pending settle-check callback, if any."""
+        if self._settle_unsub is not None:
+            self._settle_unsub()
+            self._settle_unsub = None
 
-        Runs on every push from the coordinator, regardless of who triggered the
-        move (HA, the native app, or a wall switch), so is_opening/is_closing can
-        rely on the actual reported position instead of the HCU's own
-        lastShadingDirection field.
+    def _schedule_direction_settle_check(self) -> None:
+        """Force a state refresh once DIRECTION_SETTLE_SECONDS has passed.
+
+        Without this, if the HCU sends no further push during the settle
+        window, the entity would keep showing no direction until some
+        unrelated update happens to trigger a refresh.
         """
+        self._cancel_direction_settle_check()
+        if self.hass is None:
+            return
+        self._settle_unsub = async_call_later(
+            self.hass, DIRECTION_SETTLE_SECONDS, self._async_direction_settled
+        )
+
+    @callback
+    def _async_direction_settled(self, _now: Any) -> None:
+        """Callback fired once the settle window has elapsed."""
+        self._settle_unsub = None
+        if self._channel.get("processing") == True:
+            self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Clean up any pending settle-check callback."""
+        self._cancel_direction_settle_check()
+        await super().async_will_remove_from_hass()
+
+    def _handle_coordinator_update(self) -> None:
+        """Track when the current move started and clear stale overrides once it ends."""
         if self._device_id in self.coordinator.data:
             processing = self._channel.get("processing") == True
-            new_position = self.current_cover_position
-            if (
-                processing
-                and new_position is not None
-                and self._last_known_position is not None
-            ):
-                if new_position > self._last_known_position:
-                    self._observed_direction = "opening"
-                elif new_position < self._last_known_position:
-                    self._observed_direction = "closing"
-                # unchanged position: no new information yet, keep the last one
-            if not processing:
-                self._observed_direction = None
+            if processing:
+                if self._processing_started_at is None:
+                    self._processing_started_at = time.monotonic()
+                    self._schedule_direction_settle_check()
+            else:
+                self._processing_started_at = None
+                self._cancel_direction_settle_check()
                 self._set_optimistic_direction(None)
-            if new_position is not None:
-                self._last_known_position = new_position
         super()._handle_coordinator_update()
 
     async def async_open_cover(self, **kwargs: Any) -> None:

--- a/custom_components/hcu_integration/manifest.json
+++ b/custom_components/hcu_integration/manifest.json
@@ -15,6 +15,6 @@
     "aiohttp>=3.0.0",
     "getmac>=0.8.0"
   ],
-  "version": "2.2.4",
+  "version": "2.2.5",
   "zeroconf": [{"type": "_ssh._tcp.local.", "name": "hcu1*"}]
 }

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -295,6 +295,52 @@ async def test_cover_direction_not_moving_reports_neither(mock_coordinator, mock
     assert cover.is_closing is False
 
 
+async def test_cover_position_delta_overrides_stale_direction_for_external_moves(
+    mock_coordinator, mock_hcu_client
+):
+    """Regression test for the native-app follow-up to issue #433: the direction
+    flicker also happens for moves HA never commanded (native app, wall switch),
+    where there is no local optimistic direction to fall back on at all. In that
+    case the observed change in current_cover_position must win over a stale/
+    wrong lastShadingDirection value, since HA never gets a chance to set an
+    optimistic override for externally triggered moves.
+    """
+    # Cover starts fully open (shutterLevel 0.0 -> position 100)
+    device_data = _make_shutter_device(processing=False, shutter_level=0.0)
+    mock_hcu_client.get_device_by_address = MagicMock(return_value=device_data)
+
+    cover = HcuCover(mock_coordinator, mock_hcu_client, device_data, "1")
+    cover.async_write_ha_state = MagicMock()  # entity is not attached to hass in this test
+    mock_coordinator.data = {"device-id": device_data}
+
+    # Movement starts from the native app - HA was never told, so there is no
+    # local optimistic direction. The HCU reports processing=True but its own
+    # lastShadingDirection is wrong/stale ("LIGHTER"/opening), while the actual
+    # position already shows the shutter closing (level rising -> position falling).
+    device_data["functionalChannels"]["1"]["processing"] = True
+    device_data["functionalChannels"]["1"]["lastShadingDirection"] = "LIGHTER"
+    device_data["functionalChannels"]["1"]["shutterLevel"] = 0.2  # position 80, was 100
+    cover._handle_coordinator_update()
+
+    assert cover.is_closing is True
+    assert cover.is_opening is False
+
+    # Position keeps moving in the same (closing) direction on the next push,
+    # even if lastShadingDirection is still wrong.
+    device_data["functionalChannels"]["1"]["shutterLevel"] = 0.5  # position 50
+    cover._handle_coordinator_update()
+
+    assert cover.is_closing is True
+    assert cover.is_opening is False
+
+    # Movement ends: observed direction resets.
+    device_data["functionalChannels"]["1"]["processing"] = False
+    cover._handle_coordinator_update()
+
+    assert cover.is_closing is False
+    assert cover.is_opening is False
+
+
 async def test_cover_close_command_overrides_stale_direction_flicker(
     mock_coordinator, mock_hcu_client
 ):

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -252,6 +252,137 @@ async def test_cover_group_with_none_secondary_shading_level(mock_coordinator, m
     assert cover.current_cover_position == 100  # 0.0 level = fully open
 
 
+def _make_shutter_device(processing=False, last_shading_direction=None, shutter_level=0.0):
+    """Build a minimal BROLL device_data dict for direction tests."""
+    return {
+        "id": "device-id",
+        "type": "HMIP-BROLL",
+        "functionalChannels": {
+            "1": {
+                "label": "Shutter Channel",
+                "shutterLevel": shutter_level,
+                "processing": processing,
+                "lastShadingDirection": last_shading_direction,
+            }
+        },
+    }
+
+
+async def test_cover_direction_falls_back_to_hcu_data_without_local_command(
+    mock_coordinator, mock_hcu_client
+):
+    """Without a locally issued command (e.g. movement started via the native app),
+    is_opening/is_closing should reflect the HCU-reported lastShadingDirection as before.
+    """
+    device_data = _make_shutter_device(processing=True, last_shading_direction="DARKER")
+    mock_hcu_client.get_device_by_address = MagicMock(return_value=device_data)
+
+    cover = HcuCover(mock_coordinator, mock_hcu_client, device_data, "1")
+
+    assert cover.is_closing is True
+    assert cover.is_opening is False
+
+
+async def test_cover_direction_not_moving_reports_neither(mock_coordinator, mock_hcu_client):
+    """When the HCU reports processing=False, neither opening nor closing should be true,
+    regardless of a stale lastShadingDirection value."""
+    device_data = _make_shutter_device(processing=False, last_shading_direction="LIGHTER")
+    mock_hcu_client.get_device_by_address = MagicMock(return_value=device_data)
+
+    cover = HcuCover(mock_coordinator, mock_hcu_client, device_data, "1")
+
+    assert cover.is_opening is False
+    assert cover.is_closing is False
+
+
+async def test_cover_close_command_overrides_stale_direction_flicker(
+    mock_coordinator, mock_hcu_client
+):
+    """Regression test for issue #433: after HA commands a close, the HCU may briefly
+    push processing=True together with the *previous* movement's lastShadingDirection
+    (LIGHTER/opening) before correcting it a moment later. The optimistic direction we
+    set locally on command must win over that stale value so is_closing/is_opening
+    never flicker to the wrong direction.
+    """
+    device_data = _make_shutter_device(processing=False, last_shading_direction="LIGHTER")
+    mock_hcu_client.get_device_by_address = MagicMock(return_value=device_data)
+    mock_hcu_client.async_set_shutter_level = AsyncMock()
+
+    cover = HcuCover(mock_coordinator, mock_hcu_client, device_data, "1")
+
+    await cover.async_close_cover()
+
+    # HCU push #1: processing flips to True, but direction still stale ("LIGHTER"/opening)
+    device_data["functionalChannels"]["1"]["processing"] = True
+    device_data["functionalChannels"]["1"]["lastShadingDirection"] = "LIGHTER"
+    assert cover.is_closing is True
+    assert cover.is_opening is False
+
+    # HCU push #2: direction corrected to "DARKER"/closing - still consistent
+    device_data["functionalChannels"]["1"]["lastShadingDirection"] = "DARKER"
+    assert cover.is_closing is True
+    assert cover.is_opening is False
+
+    # Movement finishes: coordinator confirms processing=False, clearing the override
+    device_data["functionalChannels"]["1"]["processing"] = False
+    mock_coordinator.data = {"device-id": device_data}
+    cover.async_write_ha_state = MagicMock()  # entity is not attached to hass in this test
+    cover._handle_coordinator_update()
+
+    assert cover._optimistic_direction is None
+    assert cover.is_closing is False
+    assert cover.is_opening is False
+
+
+async def test_cover_open_command_sets_optimistic_direction(mock_coordinator, mock_hcu_client):
+    """async_open_cover should set the optimistic direction to 'opening'."""
+    device_data = _make_shutter_device(processing=False)
+    mock_hcu_client.get_device_by_address = MagicMock(return_value=device_data)
+    mock_hcu_client.async_set_shutter_level = AsyncMock()
+
+    cover = HcuCover(mock_coordinator, mock_hcu_client, device_data, "1")
+    await cover.async_open_cover()
+
+    assert cover._optimistic_direction == "opening"
+
+
+async def test_cover_stop_command_clears_optimistic_direction(mock_coordinator, mock_hcu_client):
+    """async_stop_cover should drop any locally assumed direction."""
+    device_data = _make_shutter_device(processing=False)
+    mock_hcu_client.get_device_by_address = MagicMock(return_value=device_data)
+    mock_hcu_client.async_set_shutter_level = AsyncMock()
+    mock_hcu_client.async_stop_cover = AsyncMock()
+
+    cover = HcuCover(mock_coordinator, mock_hcu_client, device_data, "1")
+    await cover.async_close_cover()
+    assert cover._optimistic_direction == "closing"
+
+    await cover.async_stop_cover()
+    assert cover._optimistic_direction is None
+
+
+async def test_cover_set_position_infers_direction(mock_coordinator, mock_hcu_client):
+    """async_set_cover_position should infer opening/closing from the target vs. current position."""
+    # shutterLevel 0.5 -> current_cover_position 50
+    device_data = _make_shutter_device(processing=False, shutter_level=0.5)
+    mock_hcu_client.get_device_by_address = MagicMock(return_value=device_data)
+    mock_hcu_client.async_set_shutter_level = AsyncMock()
+
+    cover = HcuCover(mock_coordinator, mock_hcu_client, device_data, "1")
+
+    # Target position 80 > current 50 -> opening (moving towards fully open)
+    await cover.async_set_cover_position(position=80)
+    assert cover._optimistic_direction == "opening"
+
+    # Target position 20 < current 50 -> closing
+    await cover.async_set_cover_position(position=20)
+    assert cover._optimistic_direction == "closing"
+
+    # Target position equals current -> no movement, no direction
+    await cover.async_set_cover_position(position=50)
+    assert cover._optimistic_direction is None
+
+
 async def test_cover_device_with_none_slats_level(mock_coordinator, mock_hcu_client):
     """Test that devices with slatsLevel=None are reclassified from BLIND to SHUTTER.
 

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -361,6 +361,36 @@ async def test_cover_stop_command_clears_optimistic_direction(mock_coordinator, 
     assert cover._optimistic_direction is None
 
 
+async def test_cover_external_override_wins_back_after_grace_window(
+    mock_coordinator, mock_hcu_client
+):
+    """If something else (wall switch, native app) takes over an ongoing
+    HA-commanded move and reverses direction, our local override must not mask
+    that indefinitely - it should expire and let the real HCU-reported
+    direction win back the display.
+    """
+    device_data = _make_shutter_device(processing=False, last_shading_direction="LIGHTER")
+    mock_hcu_client.get_device_by_address = MagicMock(return_value=device_data)
+    mock_hcu_client.async_set_shutter_level = AsyncMock()
+
+    cover = HcuCover(mock_coordinator, mock_hcu_client, device_data, "1")
+
+    await cover.async_close_cover()
+    device_data["functionalChannels"]["1"]["processing"] = True
+
+    # Someone else takes over mid-move and reverses direction; the HCU now
+    # correctly reports "LIGHTER" (opening), but our override still says closing.
+    device_data["functionalChannels"]["1"]["lastShadingDirection"] = "LIGHTER"
+    assert cover.is_closing is True  # still within the grace window
+    assert cover.is_opening is False
+
+    # Simulate the grace window having elapsed without a processing=False update
+    cover._optimistic_direction_set_at -= 999
+
+    assert cover.is_closing is False
+    assert cover.is_opening is True  # real HCU data wins back
+
+
 async def test_cover_set_position_infers_direction(mock_coordinator, mock_hcu_client):
     """async_set_cover_position should infer opening/closing from the target vs. current position."""
     # shutterLevel 0.5 -> current_cover_position 50

--- a/tests/test_cover.py
+++ b/tests/test_cover.py
@@ -295,18 +295,18 @@ async def test_cover_direction_not_moving_reports_neither(mock_coordinator, mock
     assert cover.is_closing is False
 
 
-async def test_cover_position_delta_overrides_stale_direction_for_external_moves(
+async def test_cover_external_move_direction_held_back_until_settled(
     mock_coordinator, mock_hcu_client
 ):
     """Regression test for the native-app follow-up to issue #433: the direction
     flicker also happens for moves HA never commanded (native app, wall switch),
-    where there is no local optimistic direction to fall back on at all. In that
-    case the observed change in current_cover_position must win over a stale/
-    wrong lastShadingDirection value, since HA never gets a chance to set an
-    optimistic override for externally triggered moves.
+    where there is no local optimistic direction to fall back on. Since neither
+    lastShadingDirection nor current_cover_position are guaranteed to arrive
+    quickly or reliably from the HCU, we simply hold back showing any direction
+    for DIRECTION_SETTLE_SECONDS after a move starts, instead of risking the
+    wrong one.
     """
-    # Cover starts fully open (shutterLevel 0.0 -> position 100)
-    device_data = _make_shutter_device(processing=False, shutter_level=0.0)
+    device_data = _make_shutter_device(processing=False)
     mock_hcu_client.get_device_by_address = MagicMock(return_value=device_data)
 
     cover = HcuCover(mock_coordinator, mock_hcu_client, device_data, "1")
@@ -314,31 +314,36 @@ async def test_cover_position_delta_overrides_stale_direction_for_external_moves
     mock_coordinator.data = {"device-id": device_data}
 
     # Movement starts from the native app - HA was never told, so there is no
-    # local optimistic direction. The HCU reports processing=True but its own
-    # lastShadingDirection is wrong/stale ("LIGHTER"/opening), while the actual
-    # position already shows the shutter closing (level rising -> position falling).
+    # local optimistic direction. The HCU's lastShadingDirection is wrong/stale
+    # right after processing flips to True.
     device_data["functionalChannels"]["1"]["processing"] = True
     device_data["functionalChannels"]["1"]["lastShadingDirection"] = "LIGHTER"
-    device_data["functionalChannels"]["1"]["shutterLevel"] = 0.2  # position 80, was 100
     cover._handle_coordinator_update()
 
+    # Still within the settle window: neither direction is shown, rather than
+    # risking the (currently wrong) raw value.
+    assert cover.is_opening is False
+    assert cover.is_closing is False
+
+    # A moment later the HCU corrects itself, still within the settle window -
+    # still held back.
+    device_data["functionalChannels"]["1"]["lastShadingDirection"] = "DARKER"
+    cover._handle_coordinator_update()
+    assert cover.is_opening is False
+    assert cover.is_closing is False
+
+    # Simulate the settle window having elapsed: the (by now correct) raw
+    # value is trusted.
+    cover._processing_started_at -= 999
     assert cover.is_closing is True
     assert cover.is_opening is False
 
-    # Position keeps moving in the same (closing) direction on the next push,
-    # even if lastShadingDirection is still wrong.
-    device_data["functionalChannels"]["1"]["shutterLevel"] = 0.5  # position 50
-    cover._handle_coordinator_update()
-
-    assert cover.is_closing is True
-    assert cover.is_opening is False
-
-    # Movement ends: observed direction resets.
+    # Movement ends: settle tracking resets for the next move.
     device_data["functionalChannels"]["1"]["processing"] = False
     cover._handle_coordinator_update()
-
     assert cover.is_closing is False
     assert cover.is_opening is False
+    assert cover._processing_started_at is None
 
 
 async def test_cover_close_command_overrides_stale_direction_flicker(


### PR DESCRIPTION
## Description
Right after a shutter/blind starts moving, the HCU itself briefly reports the wrong `lastShadingDirection` (the previous move's direction) before correcting it a moment later. `is_opening`/`is_closing` read that field directly, so the cover entity's history/logbook briefly showed the opposite direction of what was actually happening.

This is incorrect data coming from the HCU (confirmed by testing against a real device — the raw field, and `shutterLevel`, both arrive asynchronously and can be stale), not something fixable at the source, so this PR is a client-side workaround rather than a true fix:

- **Commands sent from Home Assistant** now set the direction locally the instant they're issued (`_optimistic_direction`), instead of waiting on the HCU's own briefly-wrong report. This override is time-boxed (`OPTIMISTIC_DIRECTION_GRACE_SECONDS`, 3s) so a real external override (wall switch, native app) taking over an already-running HA-commanded move still wins back the display instead of being masked for the rest of that move.
- **Moves triggered elsewhere** (native app, wall switch), where there's no local direction to fall back on, now hold back showing any direction for `DIRECTION_SETTLE_SECONDS` (3s) after the move starts, rather than risk showing the HCU's incorrect value. A scheduled callback forces a state refresh once that window elapses so the entity updates even if no further HCU push arrives in the meantime.
- Bumped version to 2.2.5 and added a changelog entry.

## Motivation & Context
Fixes #433 — a shutter/blind briefly shows the wrong direction (opening/closing swapped) in the logbook/history right after being commanded from Home Assistant.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## How Was It Tested?
- [x] Unit tests — added regression tests in `tests/test_cover.py` covering the stale-direction-then-correction sequence for HA-issued commands, the external-override-during-an-HA-move edge case, and the settle window for externally triggered moves. Full suite: 19/19 passing in `test_cover.py`.
- [ ] Manually tested — not possible from this environment (no live HCU access). The specific timing constants (`OPTIMISTIC_DIRECTION_GRACE_SECONDS`, `DIRECTION_SETTLE_SECONDS`) would benefit from real-world verification and tuning.

## Checklist
- [x] Code follows the project style
- [x] Tests added
- [x] Documentation updated (CHANGELOG.md)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pr4u9MGQJY91bbMVBGRa4b)_

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds time-bounded optimistic direction reporting for Home Assistant cover commands and suppresses potentially stale HCU direction data at the beginning of externally initiated movements.
- Tracks locally commanded cover direction for a three-second grace period.
- Adds movement-settle timing and a delayed state refresh for external movements.
- Adds direction regression tests and bumps the integration version to 2.2.5.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should be fixed before merging because optimistic direction can remain cached beyond its grace period when a command is issued during an already-running movement.

Optimistic expiration is evaluated lazily, while the only delayed state write is tied to the original movement start and is not rescheduled for later commands, leaving Home Assistant without a guaranteed refresh at expiration.

**Files Needing Attention:** custom_components/hcu_integration/cover.py, tests/test_cover.py
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| custom_components/hcu_integration/cover.py | Adds optimistic and settle-window direction handling, but optimistic expiration is not coupled to a state refresh when commands occur during an existing movement. |
| tests/test_cover.py | Adds broad direction regression coverage but does not exercise expiry after issuing another command while processing is already true and no further HCU push arrives. |
| custom_components/hcu_integration/const.py | Updates the plugin version consistently to 2.2.5. |
| custom_components/hcu_integration/manifest.json | Updates the manifest version consistently to 2.2.5. |
| CHANGELOG.md | Documents the cover-direction workaround and release version. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant HA as Home Assistant
    participant Cover as HcuCover
    participant HCU
    HA->>Cover: "Command while processing=true"
    Cover->>Cover: Reset optimistic direction timestamp
    Cover->>HCU: Send command
    Note over Cover: Existing settle callback is not rescheduled
    Cover->>Cover: Grace period expires internally
    Note over HA,Cover: No state write occurs at expiry
    Note over HA: Cached direction remains until another update
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
custom_components/hcu_integration/cover.py:181-182
**Optimistic expiry misses refresh**

When Home Assistant issues another command while the cover is already processing, the optimistic timestamp is reset without scheduling a corresponding state refresh. If no subsequent HCU push arrives after the grace period, Home Assistant retains the previously computed direction until an unrelated update, so an external reversal does not win back the display as intended.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Raise DIRECTION\_SETTLE\_SECONDS to 3s (ma..."](https://github.com/ediminator/homematicip-hcu/commit/6b37c53fbd3acb2c0e2460c7097c223ad373b682) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58961524)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Home Assistant entity platforms](https://app.greptile.com/ediminator/-/custom-context/knowledge-base/ediminator/homematicip-hcu/-/docs/home-assistant-platforms.md)
- Knowledge Base — [Actuator entity platforms](https://app.greptile.com/ediminator/-/custom-context/knowledge-base/ediminator/homematicip-hcu/-/docs/actuator-platforms.md)

<!-- /greptile_comment -->