### PR TITLE
Added basic garage door ventilation support (for e.g. HmIP-MOD-HO)

### DIFF
--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -387,6 +387,9 @@ class HcuGarageDoorCover(HcuBaseEntity, CoverEntity):
             self._attr_supported_features = (
                 CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
             )
+        self._is_ventilationPositionSupported = "ventilationPositionSupported" in self._channel and self._channel.get("ventilationPositionSupported")
+        if self._is_ventilationPositionSupported:
+            self._attr_supported_features |= CoverEntityFeature.OPEN_TILT
 
     @property
     def is_closed(self) -> bool | None:
@@ -436,6 +439,13 @@ class HcuGarageDoorCover(HcuBaseEntity, CoverEntity):
             self._device_id, self._channel_index, "STOP"
         )
 
+    async def async_open_cover_tilt(self, **kwargs) -> None:
+        if not self._is_ventilationPositionSupported:
+            return
+        self._attr_assumed_state = True
+        await self._client.async_send_door_command(
+            self._device_id, self._channel_index, "PARTIAL_OPEN"
+        )
 
 class HcuCoverGroup(HcuGroupBaseEntity, CoverEntity):
     """Representation of an HCU Cover (shutter or blind) group."""

--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -387,7 +387,9 @@ class HcuGarageDoorCover(HcuBaseEntity, CoverEntity):
             self._attr_supported_features = (
                 CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
             )
-        self._is_ventilationPositionSupported = "ventilationPositionSupported" in self._channel
+        self._is_ventilationPositionSupported = self._channel.get(
+            "ventilationPositionSupported", False
+        )
         if self._is_ventilationPositionSupported:
             self._attr_supported_features |= CoverEntityFeature.OPEN_TILT
 

--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -387,7 +387,7 @@ class HcuGarageDoorCover(HcuBaseEntity, CoverEntity):
             self._attr_supported_features = (
                 CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
             )
-        self._is_ventilationPositionSupported = "ventilationPositionSupported" in self._channel and self._channel.get("ventilationPositionSupported")
+        self._is_ventilationPositionSupported = "ventilationPositionSupported" in self._channel
         if self._is_ventilationPositionSupported:
             self._attr_supported_features |= CoverEntityFeature.OPEN_TILT
 

--- a/custom_components/hcu_integration/cover.py
+++ b/custom_components/hcu_integration/cover.py
@@ -387,6 +387,7 @@ class HcuGarageDoorCover(HcuBaseEntity, CoverEntity):
             self._attr_supported_features = (
                 CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
             )
+
         self._is_ventilationPositionSupported = self._channel.get(
             "ventilationPositionSupported", False
         )


### PR DESCRIPTION
## Description
My Hoermann Garage Door Drive is supporting a ventilation position, therefore I added a new feature to support the ventilation function of the Garage Door Drive.
The availability of the feature is reported by the DOOR_CHANNEL:
`"ventilationPositionSupported": true`
Moving the door to the ventilation position can be done by executing a PARTIAL_OPEN
https://homematicip-rest-api.readthedocs.io/en/latest/homematicip.base.html?highlight=partial_open#homematicip.base.enums.DoorCommand.PARTIAL_OPEN

Compared to the HomematicIP app, the door has to be closed first (after moving the door to the ventilation position) before it can be opened.
This behavior is due to the Cover entity states in Home Assistant, as these are only reflecting OPEN and CLOSED and no state like PARTIAL_OPEN
https://developers.home-assistant.io/docs/core/entity/cover/#states

I have mapped this feature to the TILT feature of Home Assistant, knowing that this is not exactly the right description for this feature specially when owning sectional garage doors ;-)

## Motivation & Context
Supporting the Ventilation Position of the Garage Door.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## How Was It Tested?
- [x] Unit tests
- [x] Manually tested

## Checklist
- [x] Code follows the project style
- [x] Tests added
- [ ] Documentation updated























<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61008801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<details><summary>Summary</summary>

Adds garage-door ventilation support by mapping the HCU partial-open capability to Home Assistant tilt controls.
- Advertises open-tilt and stop-tilt only when `ventilationPositionSupported` is truthy.
- Maps closed, ventilation, and open door states to cover and tilt positions.
- Sends `PARTIAL_OPEN` when the ventilation control is activated.
- Adds tests for capability gating, state mapping, and command dispatch.
</details>

<sub>Reviews (12) · Last reviewed commit: ["Fixed comment."](https://github.com/ediminator/homematicip-hcu/commit/dba1aad69765724c7ace5eac05f1a818422cc163)</sub>

<!-- /greptile_comment -->